### PR TITLE
Wrap offers list with RefreshIndicator

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -272,9 +272,11 @@ class _MClubScreenState extends State<MClubScreen> with SingleTickerProviderStat
           Expanded(
             child: _filteredOffers.isEmpty
                 ? const Center(child: Text('Нет предложений'))
-                : ListView.builder(
-                    itemCount: _filteredOffers.length,
-                    itemBuilder: (context, index) {
+                : RefreshIndicator(
+                    onRefresh: _loadData,
+                    child: ListView.builder(
+                      itemCount: _filteredOffers.length,
+                      itemBuilder: (context, index) {
                       final offer = _filteredOffers[index];
                       final photo = (offer['photo_url'] ?? '').toString();
                       final title = (offer['title'] ?? '').toString();
@@ -367,6 +369,7 @@ class _MClubScreenState extends State<MClubScreen> with SingleTickerProviderStat
                       );
                     },
                   ),
+                ),
           ),
         ],
       );


### PR DESCRIPTION
## Summary
- wrap the offers list in `RefreshIndicator` and hook it to `_loadData`

## Testing
- `dart format lib/features/mclub/mclub_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a83d2c50e883269931e8f3d682c618