### PR TITLE
Improve mClub data loading error handling

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -102,7 +102,18 @@ class _MClubScreenState extends State<MClubScreen> with SingleTickerProviderStat
         _tabScrollController =
             Scrollable.of(_tabBarKey.currentContext!)?.widget.controller;
       });
-    } catch (e) {
+    } catch (e, stack) {
+      // Log the exception so debugging information is available in the console
+      debugPrint('Failed to load mClub data: $e');
+      debugPrintStack(stackTrace: stack);
+
+      // Inform the user about the failure with the actual error details
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Не удалось загрузить данные: $e')),
+        );
+      }
+
       setState(() => _error = 'Не удалось загрузить данные');
     } finally {
       setState(() => _isLoading = false);


### PR DESCRIPTION
## Summary
- log exceptions and stack traces when mClub data fails to load
- show a SnackBar with error details so debugging is easier

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a83ed13114832682e0f39619238154