### PR TITLE
Expose share URL on Offer and update sharing logic

### DIFF
--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -88,10 +88,11 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
   // ===== helpers
 
   void _shareOffer() {
+    final link = widget.offer.shareUrl;
+    if (link == null || link.trim().isEmpty) return;
     final title = widget.offer.title;
-    final link = widget.offer.links.shareUrl ?? '';
     final text = [title, link].where((e) => e.trim().isNotEmpty).join('\n');
-    if (text.isNotEmpty) Share.share(text);
+    Share.share(text);
   }
 
   Future<void> _openPhone(String phone) async {

--- a/lib/features/mclub/offer_model.dart
+++ b/lib/features/mclub/offer_model.dart
@@ -18,6 +18,7 @@ class Offer {
   final String? photoUrl;           // миниатюра
   final List<String> photosUrl;     // галерея
 
+  final String? shareUrl;           // ссылка для шаринга
   final List<Branch> branches;
   final OfferLinks links;
   final int rating;                 // текущий рейтинг
@@ -37,6 +38,7 @@ class Offer {
     required this.dateEnd,
     required this.photoUrl,
     required this.photosUrl,
+    required this.shareUrl,
     required this.branches,
     required this.links,
     required this.rating,
@@ -107,6 +109,7 @@ class Offer {
       dateEnd: fromUnix(json['date_end']),
       photoUrl: (json['photo_url'] as String?)?.toString(),
       photosUrl: photos,
+      shareUrl: OfferLinks._emptyToNull(json['share_url']),
       branches: branches,
       links: OfferLinks.fromJson(json['links'] as Map<String, dynamic>? ?? const {}),
       rating: int.tryParse((json['rating'] ?? '0').toString()) ?? 0,
@@ -155,13 +158,11 @@ class OfferLinks {
   final String? facebook;
   final String? instagram;
   final String? www;
-  final String? shareUrl;
 
   OfferLinks({
     this.facebook,
     this.instagram,
     this.www,
-    this.shareUrl,
   });
 
   factory OfferLinks.fromJson(Map<String, dynamic> json) {
@@ -169,7 +170,6 @@ class OfferLinks {
       facebook: _emptyToNull(json['facebook']),
       instagram: _emptyToNull(json['instagram']),
       www: _emptyToNull(json['www']),
-      shareUrl: _emptyToNull(json['share_url']),
     );
   }
 


### PR DESCRIPTION
## Summary
- add nullable `shareUrl` on `Offer`
- drop `shareUrl` from `OfferLinks`
- share offer only when `shareUrl` exists

## Testing
- `dart format lib/features/mclub/offer_model.dart lib/features/mclub/offer_detail_screen.dart` *(fails: command not found)*
- `flutter format lib/features/mclub/offer_model.dart lib/features/mclub/offer_detail_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e5746288326ac5c34424a394d3c