### PR TITLE
Fix share URL parsing for offers

### DIFF
--- a/lib/features/mclub/offer_model.dart
+++ b/lib/features/mclub/offer_model.dart
@@ -109,7 +109,8 @@ class Offer {
       dateEnd: fromUnix(json['date_end']),
       photoUrl: (json['photo_url'] as String?)?.toString(),
       photosUrl: photos,
-      shareUrl: OfferLinks._emptyToNull(json['share_url']),
+      shareUrl:
+          OfferLinks._emptyToNull((json['links'] as Map<String, dynamic>?)?['share_url']),
       branches: branches,
       links: OfferLinks.fromJson(json['links'] as Map<String, dynamic>? ?? const {}),
       rating: int.tryParse((json['rating'] ?? '0').toString()) ?? 0,


### PR DESCRIPTION
## Summary
- parse offer share link from nested `links.share_url`

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ab45610e008326bd2ae410700b38e4