### PR TITLE
Simplify social link rendering with theme icons

### DIFF
--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -162,10 +162,11 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
     }
   }
 
-  List<Widget> _buildLinkIcons(OfferLinks links) {
+  List<Widget> _buildLinkIcons(BuildContext context, OfferLinks links) {
     final items = <Widget>[];
+    final color = Theme.of(context).iconTheme.color!;
 
-    void add(String? url, String tooltip, String asset, Color color) {
+    void add(String? url, String tooltip, String asset) {
       if (url == null) return;
       items.add(
         IconButton(
@@ -181,17 +182,17 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
       );
     }
 
-    add(links.facebook, 'Facebook', 'assets/images/ic_facebook.svg', const Color(0xFF1877F2));
-    add(links.instagram, 'Instagram', 'assets/images/ic_instagram.svg', const Color(0xFFE4405F));
-    add(links.vk, 'VK', 'assets/images/ic_vk.svg', const Color(0xFF4C75A3));
-    add(links.odnoclassniki, 'Odnoklassniki', 'assets/images/ic_odnoklassniki.svg', const Color(0xFFF4731C));
-    add(links.twitter, 'Twitter', 'assets/images/ic_twitter.svg', const Color(0xFF1DA1F2));
-    add(links.linkedin, 'LinkedIn', 'assets/images/ic_linkedin.svg', const Color(0xFF0077B5));
-    add(links.youtube, 'YouTube', 'assets/images/ic_youtube.svg', const Color(0xFFFF0000));
-    add(links.www, 'Website', 'assets/images/ic_www.svg', Colors.black87);
+    add(links.facebook, 'Facebook', 'assets/images/ic_facebook.svg');
+    add(links.instagram, 'Instagram', 'assets/images/ic_instagram.svg');
+    add(links.vk, 'VK', 'assets/images/ic_vk.svg');
+    add(links.odnoclassniki, 'Odnoklassniki', 'assets/images/ic_odnoklassniki.svg');
+    add(links.twitter, 'Twitter', 'assets/images/ic_twitter.svg');
+    add(links.linkedin, 'LinkedIn', 'assets/images/ic_linkedin.svg');
+    add(links.youtube, 'YouTube', 'assets/images/ic_youtube.svg');
+    add(links.www, 'Website', 'assets/images/ic_www.svg');
 
     links.others.forEach((name, url) {
-      add(url, name, 'assets/images/ic_www.svg', Colors.black87);
+      add(url, name, 'assets/images/ic_www.svg');
     });
 
     return items;
@@ -213,7 +214,7 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
 
     final descHtml = o.descriptionHtml;
     final branches = o.branches;
-    final linkIcons = _buildLinkIcons(o.links);
+    final linkIcons = _buildLinkIcons(context, o.links);
     final ratingColor = _rating > 0 ? Colors.green : (_rating < 0 ? Colors.red : Colors.grey);
 
     final iconColor = _collapsed ? Colors.black87 : Colors.white;


### PR DESCRIPTION
## Summary
- add helper that builds link icons using the current icon theme color
- show social link icons after offer description in a padded wrap

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8b025c908326a181c38b97f9cefa