### PR TITLE
feat: add offers map screen

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -3,6 +3,7 @@ import 'package:geolocator/geolocator.dart';
 import '../../core/services/api_service.dart';
 import 'offer_detail_screen.dart';
 import 'offer_model.dart';
+import 'offers_map_screen.dart';
 
 class MClubScreen extends StatefulWidget {
   const MClubScreen({super.key});
@@ -236,6 +237,22 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
     );
   }
 
+  void _openMap() {
+    final offers = _filteredOffers
+        .map((o) => Offer.fromJson(o as Map<String, dynamic>))
+        .toList();
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => OffersMapScreen(
+          offers: offers,
+          userLat: _curLat ?? _fallbackLat,
+          userLng: _curLng ?? _fallbackLng,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     Widget body;
@@ -301,6 +318,11 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
                             ),
                           ],
                         ),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.map),
+                        tooltip: 'Карта',
+                        onPressed: _openMap,
                       ),
                       IconButton(
                         icon: const Icon(Icons.tune),

--- a/lib/features/mclub/offers_map_screen.dart
+++ b/lib/features/mclub/offers_map_screen.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+import 'offer_detail_screen.dart';
+import 'offer_model.dart';
+
+class OffersMapScreen extends StatefulWidget {
+  final List<Offer> offers;
+  final double userLat;
+  final double userLng;
+
+  const OffersMapScreen({
+    super.key,
+    required this.offers,
+    required this.userLat,
+    required this.userLng,
+  });
+
+  @override
+  State<OffersMapScreen> createState() => _OffersMapScreenState();
+}
+
+class _OffersMapScreenState extends State<OffersMapScreen> {
+  GoogleMapController? _controller;
+
+  void _showOfferCard(Offer offer) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  offer.title,
+                  style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
+                ),
+                const SizedBox(height: 8),
+                Text(offer.benefitText),
+                const SizedBox(height: 16),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => OfferDetailScreen(offer: offer),
+                        ),
+                      );
+                    },
+                    child: const Text('Перейти'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final markers = <Marker>{};
+    for (final offer in widget.offers) {
+      for (final branch in offer.branches) {
+        if (branch.lat != null && branch.lng != null) {
+          markers.add(
+            Marker(
+              markerId: MarkerId('${offer.id}_${branch.code ?? ''}'),
+              position: LatLng(branch.lat!, branch.lng!),
+              onTap: () => _showOfferCard(offer),
+            ),
+          );
+        }
+      }
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Предложения на карте'),
+      ),
+      body: GoogleMap(
+        initialCameraPosition: CameraPosition(
+          target: LatLng(widget.userLat, widget.userLng),
+          zoom: 12,
+        ),
+        markers: markers,
+        myLocationEnabled: true,
+        onMapCreated: (c) => _controller = c,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show benefits on a Google Map with interactive markers
- open map from mClub list via new button

## Testing
- `flutter format lib/features/mclub/offers_map_screen.dart lib/features/mclub/mclub_screen.dart` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b540a453f4832692511ae8bcaa210b