### PR TITLE
Add local network usage description for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .vscode/
 android/
 pubspec.lock
-ios/
+# ios/ directory is tracked to configure platform permissions
 linux/
 web/
 windows/

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>This app requires access to devices on your local network to function properly.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- track `ios/` directory and add NSLocalNetworkUsageDescription to iOS Info.plist

## Testing
- `flutter test` *(fails: Binding has not yet been initialized)*
- `flutter build ios` *(fails: Could not find a subcommand named "ios" for "flutter build")*

------
https://chatgpt.com/codex/tasks/task_e_68b546b551c083268c21b03fadc329a5