### PR TITLE
Show discount snippet in map markers

### DIFF
--- a/lib/features/mclub/offers_map_screen.dart
+++ b/lib/features/mclub/offers_map_screen.dart
@@ -45,11 +45,19 @@ class _OffersMapScreenState extends State<OffersMapScreen> {
         final lng = br.lng;
         final code = br.code;
         if (lat == null || lng == null) continue;
+        final rawBenefit = offerNonNull.benefitText.trim();
+        const maxLen = 30;
+        final snippet = rawBenefit.length > maxLen
+            ? '${rawBenefit.substring(0, maxLen - 3)}...'
+            : rawBenefit;
         _markers.add(
           Marker(
             markerId: MarkerId('${offerNonNull.id}_${code ?? i}'),
             position: LatLng(lat, lng),
-            infoWindow: InfoWindow(title: offerNonNull.title),
+            infoWindow: InfoWindow(
+              title: offerNonNull.title,
+              snippet: snippet.isEmpty ? null : snippet,
+            ),
             onTap: () => _onMarkerTap(offerNonNull),
           ),
         );


### PR DESCRIPTION
## Summary
- show offer discounts in Google Maps marker info windows
- truncate benefit text to keep info window concise

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1ec17288326b324574f3cb26e51