### PR TITLE
Handle returning map filters to mClub list

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -238,7 +238,7 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
     );
   }
 
-  void _openMap() {
+  Future<void> _openMap() async {
     final offers = <Map<String, dynamic>>[];
     for (final raw in _offers) {
       if (raw is Map<String, dynamic>) {
@@ -264,7 +264,7 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
       }
     }
 
-    Navigator.push(
+    final result = await Navigator.push<Map<String, dynamic>>(
       context,
       MaterialPageRoute(
         builder: (_) => OffersMapScreen(
@@ -277,6 +277,13 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
         ),
       ),
     );
+
+    if (result != null) {
+      setState(() {
+        _sortMode = result['sortMode'] ?? _sortMode;
+        _selectedCategoryId = result['selectedCategoryId'] as String?;
+      });
+    }
   }
 
   @override

--- a/lib/features/mclub/offers_map_screen.dart
+++ b/lib/features/mclub/offers_map_screen.dart
@@ -325,55 +325,64 @@ class _OffersMapScreenState extends State<OffersMapScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Предложения на карте'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.info_outline),
-            tooltip: 'Легенда',
-            onPressed: _showLegend,
-          ),
-          IconButton(
-            icon: const Icon(Icons.tune),
-            tooltip: 'Сортировка',
-            onPressed: _openSortModal,
-          ),
-        ],
-      ),
-      body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(8),
-            child: DropdownButton<String?>(
-              isExpanded: true,
-              value: _selectedCategoryId,
-              items: [
-                const DropdownMenuItem<String?>(
-                  value: null,
-                  child: Text('Все категории'),
-                ),
-                ...widget.categories.map(
-                  (c) => DropdownMenuItem<String?>(
-                    value: c.id,
-                    child: Text(c.name),
+    return WillPopScope(
+      onWillPop: () async {
+        Navigator.pop(context, {
+          'sortMode': _sortMode,
+          'selectedCategoryId': _selectedCategoryId,
+        });
+        return false;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Предложения на карте'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.info_outline),
+              tooltip: 'Легенда',
+              onPressed: _showLegend,
+            ),
+            IconButton(
+              icon: const Icon(Icons.tune),
+              tooltip: 'Сортировка',
+              onPressed: _openSortModal,
+            ),
+          ],
+        ),
+        body: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: DropdownButton<String?>(
+                isExpanded: true,
+                value: _selectedCategoryId,
+                items: [
+                  const DropdownMenuItem<String?>(
+                    value: null,
+                    child: Text('Все категории'),
                   ),
-                ),
-              ],
-              onChanged: _onCategoryChanged,
+                  ...widget.categories.map(
+                    (c) => DropdownMenuItem<String?>(
+                      value: c.id,
+                      child: Text(c.name),
+                    ),
+                  ),
+                ],
+                onChanged: _onCategoryChanged,
+              ),
             ),
-          ),
-          Expanded(
-            child: GoogleMap(
-              initialCameraPosition: _initialCamera,
-              markers: _markers,
-              onMapCreated: (c) {
-                _controller = c;
-                _fitBounds();
-              },
+            Expanded(
+              child: GoogleMap(
+                initialCameraPosition: _initialCamera,
+                markers: _markers,
+                onMapCreated: (c) {
+                  _controller = c;
+                  _fitBounds();
+                },
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Pass current category and sort settings when opening offers map
- Return chosen filters from map screen and apply to list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5acfc750083268503711175c7805c