### PR TITLE
Add faIcon field parsing for Category

### DIFF
--- a/lib/features/mclub/category_model.dart
+++ b/lib/features/mclub/category_model.dart
@@ -9,7 +9,7 @@ class Category {
     return Category(
       id: json['id']?.toString() ?? '',
       name: json['name']?.toString() ?? '',
-      faIcon: json['faIcon']?.toString(),
+      faIcon: json['fa_icon']?.toString(),
     );
   }
 }


### PR DESCRIPTION
## Summary
- parse `fa_icon` from category JSON into new optional `faIcon` field

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bd490f3483268f7152e035050b70