### PR TITLE
feat: use category icons for map markers

### DIFF
--- a/lib/features/mclub/category_model.dart
+++ b/lib/features/mclub/category_model.dart
@@ -1,13 +1,15 @@
 class Category {
   final String id;
   final String name;
+  final String mIcon;
 
-  Category({required this.id, required this.name});
+  Category({required this.id, required this.name, required this.mIcon});
 
   factory Category.fromJson(Map<String, dynamic> json) {
     return Category(
       id: json['id']?.toString() ?? '',
       name: json['name']?.toString() ?? '',
+      mIcon: json['m_icon']?.toString() ?? '',
     );
   }
 }

--- a/lib/features/mclub/icon_utils.dart
+++ b/lib/features/mclub/icon_utils.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Returns [IconData] for a given Material icon [name].
+///
+/// Only a subset of icons is supported. If the icon name is not found,
+/// `null` is returned.
+IconData? materialIconFromString(String name) {
+  switch (name) {
+    case 'local_offer':
+      return Icons.local_offer;
+    case 'restaurant':
+      return Icons.restaurant;
+    case 'shopping_bag':
+      return Icons.shopping_bag;
+    case 'shopping_cart':
+      return Icons.shopping_cart;
+    case 'directions_car':
+      return Icons.directions_car;
+    case 'sports_soccer':
+      return Icons.sports_soccer;
+    case 'fitness_center':
+      return Icons.fitness_center;
+    case 'spa':
+      return Icons.spa;
+    case 'hotel':
+      return Icons.hotel;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `mIcon` to category model
- provide helper to map Material icon names to `IconData`
- render category icons as Google Map markers and legend

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cacafa408326a561dec4ec5258d1