### PR TITLE
Add local hospital icon mapping

### DIFF
--- a/lib/features/mclub/icon_utils.dart
+++ b/lib/features/mclub/icon_utils.dart
@@ -24,6 +24,8 @@ IconData? materialIconFromString(String name) {
       return Icons.spa;
     case 'hotel':
       return Icons.hotel;
+    case 'local_hospital':
+      return Icons.local_hospital;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary
- include mapping for `local_hospital` icon in `materialIconFromString`

## Testing
- `flutter build apk` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cd2835e48326a6793f9b41eacefc