### PR TITLE
Use widget markers instead of asset images

### DIFF
--- a/lib/features/mclub/marker_generator.dart
+++ b/lib/features/mclub/marker_generator.dart
@@ -11,17 +11,17 @@ class MarkerGenerator {
     required Size size,
   }) async {
     WidgetsFlutterBinding.ensureInitialized();
-
     final repaintBoundary = RenderRepaintBoundary();
+    final uiView = WidgetsBinding.instance.platformDispatcher.implicitView!;
     final renderView = RenderView(
-      window: WidgetsBinding.instance.window,
+      view: uiView,
       child: RenderPositionedBox(
         alignment: Alignment.center,
         child: repaintBoundary,
       ),
       configuration: ViewConfiguration(
         size: size,
-        devicePixelRatio: WidgetsBinding.instance.window.devicePixelRatio,
+        devicePixelRatio: uiView.devicePixelRatio,
       ),
     );
 
@@ -45,7 +45,7 @@ class MarkerGenerator {
     pipelineOwner.flushPaint();
 
     final ui.Image image = await repaintBoundary.toImage(
-      pixelRatio: WidgetsBinding.instance.window.devicePixelRatio,
+      pixelRatio: uiView.devicePixelRatio,
     );
     final ByteData? bytes =
         await image.toByteData(format: ui.ImageByteFormat.png);

--- a/lib/features/mclub/offers_map_screen.dart
+++ b/lib/features/mclub/offers_map_screen.dart
@@ -55,11 +55,16 @@ class _OffersMapScreenState extends State<OffersMapScreen> {
   }
 
   Future<void> _initCategoryIcons() async {
-    for (final cat in widget.categories) {
+    for (var i = 0; i < widget.categories.length; i++) {
+      final cat = widget.categories[i];
       final iconData = materialIconFromString(cat.mIcon);
       if (iconData != null) {
-        _categoryIcons[cat.id] =
-            await _bitmapDescriptorFromIcon(iconData, size: markerSize);
+        final color = Colors.primaries[i % Colors.primaries.length];
+        _categoryIcons[cat.id] = await _bitmapDescriptorFromIcon(
+          iconData,
+          color: color,
+          size: markerSize,
+        );
       }
     }
     if (mounted) setState(_buildMarkers);


### PR DESCRIPTION
## Summary
- generate map markers from widgets and handle rendering via implicit view
- colorize category markers using widget-based generator

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b5ff54236c83269670383b318b7afa