### PR TITLE
feat: add offer favorite flag

### DIFF
--- a/lib/features/mclub/offer_model.dart
+++ b/lib/features/mclub/offer_model.dart
@@ -23,6 +23,7 @@ class Offer {
   final OfferLinks links;
   final int rating;                 // текущий рейтинг
   final int? vote;                  // голос пользователя
+  final bool isFavorite;
 
   Offer({
     required this.id,
@@ -43,6 +44,7 @@ class Offer {
     required this.links,
     required this.rating,
     required this.vote,
+    required this.isFavorite,
   });
 
   factory Offer.fromJson(Map<String, dynamic> json) {
@@ -118,6 +120,7 @@ class Offer {
       links: links,
       rating: int.tryParse((json['rating'] ?? '0').toString()) ?? 0,
       vote: json['vote'] == null ? null : int.tryParse(json['vote'].toString()),
+      isFavorite: json['is_favorite'] == true,
     );
   }
 }


### PR DESCRIPTION
## Summary
- extend `Offer` model with an `isFavorite` flag and wire it to JSON

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd95e58f688326ad5b5235a280987f