### PR TITLE
feat(api): add toggleFavorite service method

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -77,6 +77,25 @@ class ApiService {
     };
   }
 
+  /// Изменить состояние избранного для предложения
+  /// [id] - идентификатор предложения
+  /// Возвращает текущий признак избранного
+  Future<bool> toggleFavorite(int id) async {
+    try {
+      final formData = FormData.fromMap({'id': id});
+      final res = await _dio.post('/benefits/favorites', data: formData);
+      if (res.data is Map && res.data['is_favorite'] is bool) {
+        return res.data['is_favorite'] as bool;
+      }
+      return false;
+    } catch (e) {
+      if (kDebugMode) {
+        print('toggleFavorite error: $e');
+      }
+      rethrow;
+    }
+  }
+
   /// Очистить токен (логаут)
   Future<void> logout() async {
     await _storage.delete(key: 'auth_token');


### PR DESCRIPTION
## Summary
- add toggleFavorite to ApiService to toggle favorites via POST endpoint

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb2057d808326a7121f2871115e76