### PR TITLE
Return favorite status from offer detail screen

### DIFF
--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -237,7 +237,7 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
 
     return WillPopScope(
       onWillPop: () async {
-        Navigator.of(context).pop(_userVote);
+        Navigator.of(context).pop(_isFavorite);
         return false;
       },
       child: AnnotatedRegion<SystemUiOverlayStyle>(
@@ -254,7 +254,7 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
               expandedHeight: _expandedHeight,
               leading: IconButton(
                 icon: Icon(Icons.arrow_back, color: iconColor),
-                onPressed: () => Navigator.of(context).pop(_userVote),
+                onPressed: () => Navigator.of(context).pop(_isFavorite),
                 tooltip: 'Назад',
               ),
               actions: [

--- a/lib/features/mclub/offers_map_screen.dart
+++ b/lib/features/mclub/offers_map_screen.dart
@@ -222,14 +222,48 @@ class _OffersMapScreenState extends State<OffersMapScreen> {
                   Align(
                     alignment: Alignment.centerRight,
                     child: ElevatedButton(
-                      onPressed: () {
+                      onPressed: () async {
                         Navigator.pop(ctx);
-                        Navigator.push(
+                        final fav = await Navigator.push<bool?>(
                           context,
                           MaterialPageRoute(
                             builder: (_) => OfferDetailScreen(offer: offer),
                           ),
                         );
+                        if (!mounted) return;
+                        if (fav is bool && fav != offer.isFavorite) {
+                          setState(() {
+                            for (var i = 0; i < widget.offers.length; i++) {
+                              final raw = widget.offers[i];
+                              if (raw is Map<String, dynamic> && raw['id']?.toString() == offer.id) {
+                                raw['is_favorite'] = fav;
+                              } else if (raw is Offer && raw.id == offer.id) {
+                                widget.offers[i] = Offer(
+                                  id: raw.id,
+                                  categoryIds: raw.categoryIds,
+                                  categoryNames: raw.categoryNames,
+                                  title: raw.title,
+                                  titleShort: raw.titleShort,
+                                  descriptionShort: raw.descriptionShort,
+                                  descriptionHtml: raw.descriptionHtml,
+                                  benefitText: raw.benefitText,
+                                  benefitPercent: raw.benefitPercent,
+                                  dateStart: raw.dateStart,
+                                  dateEnd: raw.dateEnd,
+                                  photoUrl: raw.photoUrl,
+                                  photosUrl: raw.photosUrl,
+                                  shareUrl: raw.shareUrl,
+                                  branches: raw.branches,
+                                  links: raw.links,
+                                  rating: raw.rating,
+                                  vote: raw.vote,
+                                  isFavorite: fav,
+                                );
+                              }
+                            }
+                            _buildMarkers();
+                          });
+                        }
                       },
                       child: const Text('Подробнее'),
                     ),


### PR DESCRIPTION
## Summary
- Ensure OfferDetailScreen pops with favorite flag instead of vote when back navigation occurs
- Propagate favorite status from OfferDetailScreen to OffersMapScreen using Navigator.push<bool?>

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb9082764832690b56551861f72d6