### PR TITLE
Handle favorite toggle without immediate pop

### DIFF
--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -105,7 +105,6 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
       final fav = await _api.toggleFavorite(id);
       if (!mounted) return;
       setState(() => _isFavorite = fav);
-      Navigator.of(context).pop(fav);
     } catch (_) {
       // ignore errors
     }


### PR DESCRIPTION
## Summary
- Do not pop the navigator when toggling favorite on offer detail
- Allow the state to update in place via `setState`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdba997ed083268c402fdd03f540e6