### PR TITLE
Highlight favorite icon in offer details

### DIFF
--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -272,7 +272,7 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
                 IconButton(
                   icon: Icon(
                     _isFavorite ? Icons.favorite : Icons.favorite_border,
-                    color: iconColor,
+                    color: _isFavorite ? Colors.red : iconColor,
                   ),
                   onPressed: _toggleFavorite,
                   tooltip: 'Избранное',


### PR DESCRIPTION
## Summary
- Show favorite icon in red when an offer is favorited

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbe7fe28083269b2a1c561c831f06