### PR TITLE
Fix toggleFavorite boolean parsing

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -84,8 +84,14 @@ class ApiService {
     try {
       final formData = FormData.fromMap({'id': id});
       final res = await _dio.post('/benefits/favorites', data: formData);
-      if (res.data is Map && res.data['is_favorite'] is bool) {
-        return res.data['is_favorite'] as bool;
+      if (res.data is Map) {
+        final data = res.data as Map;
+        if (data['favorites'] is bool) {
+          return data['favorites'] as bool;
+        }
+        if (data['is_favorite'] is bool) {
+          return data['is_favorite'] as bool;
+        }
       }
       return false;
     } catch (e) {


### PR DESCRIPTION
## Summary
- handle `favorites` field returned from API when toggling favorites

## Testing
- `/tmp/flutter/bin/flutter test` *(fails: TimeoutException after 0:00:30.000000: Test timed out after 30 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc3a5d33c8326ad75ddf924e0b21c