### PR TITLE
feat: optimistic favorite toggle

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -185,6 +185,35 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
     }
   }
 
+  Future<void> _toggleFavoriteOffer(Map<String, dynamic> offer) async {
+    final id = int.tryParse((offer['id'] ?? '').toString());
+    if (id == null) return;
+    final prevFav = offer['is_favorite'] == true;
+    setState(() {
+      offer['is_favorite'] = !prevFav;
+    });
+    try {
+      final fav = await _api.toggleFavorite(id);
+      if (fav != offer['is_favorite'] && mounted) {
+        setState(() {
+          offer['is_favorite'] = prevFav;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Не удалось изменить избранное')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          offer['is_favorite'] = prevFav;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Не удалось изменить избранное')),
+        );
+      }
+    }
+  }
+
   void _centerSelectedTab() {
     if (_tabController == null || _tabScrollController == null) return;
     final index = _tabController!.index;
@@ -427,15 +456,23 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
                                       height: imageHeight,
                                       color: Colors.grey.shade200,
                                     ),
-                                  if (isFavorite)
-                                    const Positioned(
-                                      top: 8,
-                                      right: 8,
-                                      child: Icon(
-                                        Icons.favorite,
-                                        color: Colors.pink,
+                                  Positioned(
+                                    top: 8,
+                                    right: 8,
+                                    child: IconButton(
+                                      icon: Icon(
+                                        isFavorite
+                                            ? Icons.favorite
+                                            : Icons.favorite_border,
+                                        color: isFavorite
+                                            ? Colors.pink
+                                            : Colors.white,
                                       ),
+                                      onPressed: () =>
+                                          _toggleFavoriteOffer(
+                                              offer as Map<String, dynamic>),
                                     ),
+                                  ),
                                 ],
                               ),
                               Padding(

--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -105,19 +105,20 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
     if (mounted) {
       setState(() => _isFavorite = !_isFavorite);
     }
-    bool? fav;
     try {
-      fav = await _api.toggleFavorite(id);
+      final fav = await _api.toggleFavorite(id);
+      if (mounted && fav != _isFavorite) {
+        setState(() => _isFavorite = prevFav);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Не удалось изменить избранное')),
+        );
+      }
     } catch (_) {
       if (mounted) {
         setState(() => _isFavorite = prevFav);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Не удалось изменить избранное')),
         );
-      }
-    } finally {
-      if (fav != null && mounted) {
-        setState(() => _isFavorite = fav!);
       }
     }
   }


### PR DESCRIPTION
## Summary
- show favorite state immediately when tapping heart in offer details and revert on failure
- allow toggling favorite from list cards with optimistic update
- use consistent pink color for active favorites

## Testing
- `dart format lib/features/mclub/offer_detail_screen.dart lib/features/mclub/mclub_screen.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bdc7b2115c8326bc39c6164406a4b6