### PR TITLE
Handle favorite toggle response correctly

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -194,9 +194,16 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
     });
     try {
       final fav = await _api.toggleFavorite(id);
-      if (fav != offer['is_favorite'] && mounted) {
+      if (!mounted) return;
+      if (fav == null) {
         setState(() {
           offer['is_favorite'] = prevFav;
+        });
+        return;
+      }
+      if (fav != offer['is_favorite']) {
+        setState(() {
+          offer['is_favorite'] = fav;
         });
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Не удалось изменить избранное')),

--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -107,8 +107,13 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
     }
     try {
       final fav = await _api.toggleFavorite(id);
-      if (mounted && fav != _isFavorite) {
+      if (!mounted) return;
+      if (fav == null) {
         setState(() => _isFavorite = prevFav);
+        return;
+      }
+      if (fav != _isFavorite) {
+        setState(() => _isFavorite = fav);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Не удалось изменить избранное')),
         );


### PR DESCRIPTION
## Summary
- parse favorites response more robustly in ApiService and support null when server omits flag
- update mClub offer and detail screens to use nullable favorite response and avoid false error snackbar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb10f79c832697f9b8dc0f4a82c0