### PR TITLE
Add parseBool utility for consistent is_favorite handling

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -2,6 +2,7 @@ import 'dart:ui' as ui;
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:m_club/core/utils/parse_bool.dart';
 
 class ApiService {
   static final ApiService _instance = ApiService._internal();
@@ -91,13 +92,10 @@ class ApiService {
         final value = data.containsKey('favorites')
             ? data['favorites']
             : data['is_favorite'];
-        if (value is bool) return value;
-        if (value is String) {
-          final v = value.toLowerCase();
-          if (v == 'true' || v == '1') return true;
-          if (v == 'false' || v == '0') return false;
+        if (value == null) return null;
+        if (value is bool || value is String || value is num) {
+          return parseBool(value);
         }
-        if (value is num) return value != 0;
       }
       return null;
     } catch (e) {

--- a/lib/core/utils/parse_bool.dart
+++ b/lib/core/utils/parse_bool.dart
@@ -1,0 +1,11 @@
+bool parseBool(dynamic v) {
+  if (v is bool) return v;
+  if (v is num) return v != 0;
+  if (v is String) {
+    final lower = v.toLowerCase();
+    if (lower == 'true' || lower == '1') return true;
+    final n = num.tryParse(lower);
+    if (n != null) return n != 0;
+  }
+  return false;
+}

--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import '../../core/services/api_service.dart';
+import 'package:m_club/core/utils/parse_bool.dart';
 import 'offer_detail_screen.dart';
 import 'offer_model.dart';
 import 'offers_map_screen.dart';
@@ -188,7 +189,7 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
   Future<void> _toggleFavoriteOffer(Map<String, dynamic> offer) async {
     final id = int.tryParse((offer['id'] ?? '').toString());
     if (id == null) return;
-    final prevFav = offer['is_favorite'] == true;
+    final prevFav = parseBool(offer['is_favorite']);
     setState(() {
       offer['is_favorite'] = !prevFav;
     });
@@ -411,7 +412,7 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
                         final title = (offer['title'] ?? '').toString();
                         final descr =
                             (offer['description_short'] ?? '').toString();
-                        final isFavorite = offer['is_favorite'] == true;
+                        final isFavorite = parseBool(offer['is_favorite']);
 
                         double? distance;
                         if (_sortMode == 'distance') {

--- a/lib/features/mclub/offer_model.dart
+++ b/lib/features/mclub/offer_model.dart
@@ -1,3 +1,5 @@
+import 'package:m_club/core/utils/parse_bool.dart';
+
 class Offer {
   final String id;
   final List<String> categoryIds;   // из category[].id
@@ -120,7 +122,7 @@ class Offer {
       links: links,
       rating: int.tryParse((json['rating'] ?? '0').toString()) ?? 0,
       vote: json['vote'] == null ? null : int.tryParse(json['vote'].toString()),
-      isFavorite: json['is_favorite'] == true,
+      isFavorite: parseBool(json['is_favorite']),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add `parseBool` utility to normalize truthy values
- use `parseBool` in `Offer.fromJson` and `MClubScreen` favorite checks
- apply `parseBool` in API service when reading favorite status

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdce2da7a88326a98ad4c7c7eabc86