### PR TITLE
Simplify favorite toggling for offers

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -186,42 +186,6 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
     }
   }
 
-  Future<void> _toggleFavoriteOffer(Map<String, dynamic> offer) async {
-    final id = int.tryParse((offer['id'] ?? '').toString());
-    if (id == null) return;
-    final prevFav = parseBool(offer['is_favorite']);
-    setState(() {
-      offer['is_favorite'] = !prevFav;
-    });
-    try {
-      final fav = await _api.toggleFavorite(id);
-      if (!mounted) return;
-      if (fav == null) {
-        setState(() {
-          offer['is_favorite'] = prevFav;
-        });
-        return;
-      }
-      if (fav != offer['is_favorite']) {
-        setState(() {
-          offer['is_favorite'] = fav;
-        });
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось изменить избранное')),
-        );
-      }
-    } catch (_) {
-      if (mounted) {
-        setState(() {
-          offer['is_favorite'] = prevFav;
-        });
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось изменить избранное')),
-        );
-      }
-    }
-  }
-
   void _centerSelectedTab() {
     if (_tabController == null || _tabScrollController == null) return;
     final index = _tabController!.index;
@@ -476,9 +440,18 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
                                             ? Colors.pink
                                             : Colors.white,
                                       ),
-                                      onPressed: () =>
-                                          _toggleFavoriteOffer(
-                                              offer as Map<String, dynamic>),
+                                      onPressed: () async {
+                                        final id = int.tryParse(
+                                            (offer['id'] ?? '').toString());
+                                        if (id == null) return;
+                                        setState(() => offer['is_favorite'] =
+                                            !parseBool(offer['is_favorite']));
+                                        try {
+                                          await _api.toggleFavorite(id);
+                                        } catch (_) {
+                                          // ignore errors
+                                        }
+                                      },
                                     ),
                                   ),
                                 ],

--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -101,30 +101,13 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
   Future<void> _toggleFavorite() async {
     final id = int.tryParse(widget.offer.id);
     if (id == null) return;
-    final prevFav = _isFavorite;
     if (mounted) {
       setState(() => _isFavorite = !_isFavorite);
     }
     try {
-      final fav = await _api.toggleFavorite(id);
-      if (!mounted) return;
-      if (fav == null) {
-        setState(() => _isFavorite = prevFav);
-        return;
-      }
-      if (fav != _isFavorite) {
-        setState(() => _isFavorite = fav);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось изменить избранное')),
-        );
-      }
+      await _api.toggleFavorite(id);
     } catch (_) {
-      if (mounted) {
-        setState(() => _isFavorite = prevFav);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Не удалось изменить избранное')),
-        );
-      }
+      // ignore errors
     }
   }
 


### PR DESCRIPTION
## Summary
- Update offer list favorite button to flip local state instantly and call the API without rollback
- Simplify offer detail favorite handler to only toggle state and fire API request

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd0b218b8832680b86ad8049cf850