### PR TITLE
feat: add club card barcode widget

### DIFF
--- a/lib/features/auth/club_card.dart
+++ b/lib/features/auth/club_card.dart
@@ -1,0 +1,80 @@
+import 'package:barcode_widget/barcode_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class ClubCard extends StatelessWidget {
+  final String cardNum;
+  final String expireDate;
+
+  const ClubCard({super.key, required this.cardNum, required this.expireDate});
+
+  String _formatExpiry(String date) {
+    final parts = date.split('/');
+    if (parts.length >= 2) {
+      final month = parts[0].padLeft(2, '0');
+      var year = parts[1];
+      if (year.length == 4) {
+        year = year.substring(2);
+      }
+      return '$month/$year';
+    }
+    return date;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final formattedDate = _formatExpiry(expireDate);
+
+    return Container(
+      width: 320,
+      height: 200,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        gradient: const LinearGradient(
+          colors: [Color(0xFF182857), Color(0xFF4A5699)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SvgPicture.asset(
+            'assets/images/mclub_logo.svg',
+            height: 40,
+            colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+          ),
+          const Spacer(),
+          Text(
+            cardNum,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 20,
+              letterSpacing: 1.5,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'VALID THRU $formattedDate',
+            style: const TextStyle(color: Colors.white70, fontSize: 12),
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: BarcodeWidget(
+                barcode: Barcode.code128(),
+                data: cardNum,
+                width: double.infinity,
+                height: 60,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/auth/profile_screen.dart
+++ b/lib/features/auth/profile_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import '../../core/services/api_service.dart';
 import 'user_profile.dart';
+import 'club_card.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -151,17 +153,23 @@ class _ProfileScreenState extends State<ProfileScreen> {
   }
 
   Widget _buildCardTab() {
-    if (_profile == null) {
+    final profile = _profile;
+    if (profile == null) {
       return const SizedBox();
     }
+
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text('Карта № ${_profile!.cardNum}'),
-          const SizedBox(height: 8),
-          Text('Действительна до: ${_profile!.expireDate}'),
-        ],
+      child: GestureDetector(
+        onTap: () {
+          Clipboard.setData(ClipboardData(text: profile.cardNum));
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Номер карты скопирован')),
+          );
+        },
+        child: ClubCard(
+          cardNum: profile.cardNum,
+          expireDate: profile.expireDate,
+        ),
       ),
     );
   }
@@ -215,4 +223,3 @@ class _ProfileScreenState extends State<ProfileScreen> {
     );
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   carousel_slider: ^5.1.1
   flutter_svg: ^2.0.10+1
+  barcode_widget: ^2.0.4
 
 dev_dependencies:
   flutter_test:

--- a/test/core/services/api_service_test.dart
+++ b/test/core/services/api_service_test.dart
@@ -4,9 +4,10 @@ import 'package:m_club/core/services/api_service.dart';
 import 'package:m_club/features/auth/user_profile.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   test('voteBenefit returns actual rating and vote', () async {
     final service = ApiService();
-
+    service.dio.interceptors.clear();
     service.dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {
@@ -31,7 +32,7 @@ void main() {
 
   test('fetchProfile parses response into UserProfile', () async {
     final service = ApiService();
-
+    service.dio.interceptors.clear();
     service.dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {
@@ -67,9 +68,10 @@ void main() {
     service.dio.interceptors.clear();
   });
 
-  test('updateProfile sends only provided fields and returns profile', () async {
+  test('updateProfile sends only provided fields and returns profile',
+      () async {
     final service = ApiService();
-
+    service.dio.interceptors.clear();
     service.dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {
@@ -108,7 +110,7 @@ void main() {
 
   test('updateProfile throws DioException on error status', () async {
     final service = ApiService();
-
+    service.dio.interceptors.clear();
     service.dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {


### PR DESCRIPTION
## Summary
- add barcode_widget dependency
- implement ClubCard with gradient, logo, and Code128 barcode
- show ClubCard in profile screen and allow tapping to copy number
- stabilize ApiService tests by initializing widgets binding and clearing interceptors

## Testing
- `flutter test`
- `flutter analyze` *(22 issues, mostly warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68be08bf2af48326938c4cfd2178c620