### PR TITLE
Handle ISO dates in club card expiry

### DIFF
--- a/lib/features/auth/club_card.dart
+++ b/lib/features/auth/club_card.dart
@@ -9,16 +9,23 @@ class ClubCard extends StatelessWidget {
   const ClubCard({super.key, required this.cardNum, required this.expireDate});
 
   String _formatExpiry(String date) {
-    final parts = date.split('/');
-    if (parts.length >= 2) {
-      final month = parts[0].padLeft(2, '0');
-      var year = parts[1];
-      if (year.length == 4) {
-        year = year.substring(2);
-      }
+    try {
+      final parsed = DateTime.parse(date);
+      final month = parsed.month.toString().padLeft(2, '0');
+      final year = (parsed.year % 100).toString().padLeft(2, '0');
       return '$month/$year';
+    } catch (_) {
+      final parts = date.split('/');
+      if (parts.length >= 2) {
+        final month = parts[0].padLeft(2, '0');
+        var year = parts[1];
+        if (year.length == 4) {
+          year = year.substring(2);
+        }
+        return '$month/$year';
+      }
+      return date;
     }
-    return date;
   }
 
   @override

--- a/test/features/auth/club_card_test.dart
+++ b/test/features/auth/club_card_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_club/features/auth/club_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('formats YYYY-MM-DD into MM/YY', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: ClubCard(cardNum: '123', expireDate: '2025-08-15'),
+      ),
+    );
+    expect(find.text('VALID THRU 08/25'), findsOneWidget);
+  });
+
+  testWidgets('formats MM/YY input', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: ClubCard(cardNum: '123', expireDate: '08/25'),
+      ),
+    );
+    expect(find.text('VALID THRU 08/25'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- parse `YYYY-MM-DD` expiry strings with `DateTime.parse` and format as `MM/YY`
- add tests for both ISO and `MM/YY` expiry inputs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be136d0fc48326a6c8b1efc4924ca1