### PR TITLE
feat: show verification status in profile

### DIFF
--- a/lib/features/auth/profile_screen.dart
+++ b/lib/features/auth/profile_screen.dart
@@ -21,6 +21,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
   bool _isLoading = false;
   bool _isSaving = false;
+  bool _isEditing = false;
   String? _error;
   UserProfile? _profile;
 
@@ -84,6 +85,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
           _profile = upd;
           _phoneCtrl.text = upd.phone;
           _emailCtrl.text = upd.email;
+          _isEditing = false;
         });
       }
       if (mounted) {
@@ -104,7 +106,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
     }
   }
 
-  Widget _buildProfileTab() {
+  Widget _buildEditForm() {
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Form(
@@ -136,20 +138,80 @@ class _ProfileScreenState extends State<ProfileScreen> {
               readOnly: true,
             ),
             const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: _isSaving ? null : _saveProfile,
-              child: _isSaving
-                  ? const SizedBox(
-                      height: 16,
-                      width: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Text('Сохранить'),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _isSaving ? null : _saveProfile,
+                    child: _isSaving
+                        ? const SizedBox(
+                            height: 16,
+                            width: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Сохранить'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: _isSaving
+                        ? null
+                        : () => setState(() => _isEditing = false),
+                    child: const Text('Отмена'),
+                  ),
+                ),
+              ],
             ),
           ],
         ),
       ),
     );
+  }
+
+  Widget _buildViewProfile() {
+    final profile = _profile;
+    if (profile == null) return const SizedBox();
+
+    Widget buildTile(String label, String value, {bool? verified}) {
+      return ListTile(
+        contentPadding: EdgeInsets.zero,
+        title: Text(label),
+        subtitle: Text(value),
+        trailing: verified == null
+            ? null
+            : Icon(
+                verified ? Icons.check_circle : Icons.error,
+                color: verified ? Colors.green : Colors.red,
+              ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: ListView(
+        children: [
+          buildTile('Имя', profile.name),
+          const SizedBox(height: 12),
+          buildTile('Фамилия', profile.lastname),
+          const SizedBox(height: 12),
+          buildTile('Телефон', profile.phone,
+              verified: profile.isVerifiedPhone),
+          const SizedBox(height: 12),
+          buildTile('Email', profile.email,
+              verified: profile.isVerifiedEmail),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () => setState(() => _isEditing = true),
+            child: const Text('Редактировать'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProfileTab() {
+    return _isEditing ? _buildEditForm() : _buildViewProfile();
   }
 
   Widget _buildCardTab() {

--- a/lib/features/auth/user_profile.dart
+++ b/lib/features/auth/user_profile.dart
@@ -10,6 +10,7 @@ class UserProfile {
   final String email;
   final String login;
   final bool isVerifiedPhone;
+  final bool isVerifiedEmail;
   final bool isUaeResident;
   final String lang;
 
@@ -23,6 +24,7 @@ class UserProfile {
     required this.email,
     required this.login,
     required this.isVerifiedPhone,
+    required this.isVerifiedEmail,
     required this.isUaeResident,
     required this.lang,
   });
@@ -38,6 +40,7 @@ class UserProfile {
       email: json['email']?.toString() ?? '',
       login: json['login']?.toString() ?? '',
       isVerifiedPhone: parseBool(json['is_verified_phone']),
+      isVerifiedEmail: parseBool(json['is_verified_email']),
       isUaeResident: parseBool(json['is_uae_resident']),
       lang: json['lang']?.toString() ?? '',
     );
@@ -54,6 +57,7 @@ class UserProfile {
       'email': email,
       'login': login,
       'is_verified_phone': isVerifiedPhone,
+      'is_verified_email': isVerifiedEmail,
       'is_uae_resident': isUaeResident,
       'lang': lang,
     };

--- a/test/core/services/api_service_test.dart
+++ b/test/core/services/api_service_test.dart
@@ -51,6 +51,7 @@ void main() {
                 'email': 'john@example.com',
                 'login': 'john',
                 'is_verified_phone': 1,
+                'is_verified_email': 1,
                 'is_uae_resident': 0,
                 'lang': 'en',
               },
@@ -64,6 +65,7 @@ void main() {
     expect(profile, isA<UserProfile>());
     expect(profile.name, 'John');
     expect(profile.lastname, 'Doe');
+    expect(profile.isVerifiedEmail, true);
 
     service.dio.interceptors.clear();
   });
@@ -92,6 +94,7 @@ void main() {
                 'email': 'john@example.com',
                 'login': 'john',
                 'is_verified_phone': 1,
+                'is_verified_email': 0,
                 'is_uae_resident': 0,
                 'lang': 'en',
               },


### PR DESCRIPTION
## Summary
- add `isVerifiedEmail` to user profile model and JSON parsing
- show profile data in view mode with verification icons and edit toggle
- cover email verification in API service tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be180931148326ae671267fa9fd494