### PR TITLE
feat: implement profile deletion

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -155,6 +155,18 @@ class ApiService {
     }
   }
 
+  /// Удалить профиль пользователя
+  Future<void> deleteProfile() async {
+    try {
+      await _dio.delete('/user/delete');
+    } catch (e) {
+      if (kDebugMode) {
+        print('deleteProfile error: $e');
+      }
+      rethrow;
+    }
+  }
+
   /// Очистить токен (логаут)
   Future<void> logout() async {
     await _storage.delete(key: 'auth_token');


### PR DESCRIPTION
## Summary
- add `deleteProfile` API call
- allow users to delete profile with confirmation dialog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1f64df048326920ce77b1afa4d85