### PR TITLE
feat: add profile avatar

### DIFF
--- a/lib/features/auth/profile_screen.dart
+++ b/lib/features/auth/profile_screen.dart
@@ -229,6 +229,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
       padding: const EdgeInsets.all(16),
       child: ListView(
         children: [
+          ProfileHeader(profile: profile),
+          const SizedBox(height: 24),
           buildTile('Имя', profile.name),
           const SizedBox(height: 12),
           buildTile('Фамилия', profile.lastname),
@@ -339,6 +341,40 @@ class _ProfileScreenState extends State<ProfileScreen> {
             _buildCardTab(),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class ProfileHeader extends StatelessWidget {
+  const ProfileHeader({super.key, required this.profile});
+
+  final UserProfile profile;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CircleAvatar(
+            radius: 40,
+            backgroundImage:
+                profile.avatarUrl.isNotEmpty ? NetworkImage(profile.avatarUrl) : null,
+            child: profile.avatarUrl.isEmpty
+                ? const Icon(Icons.person, size: 40)
+                : null,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            '${profile.name} ${profile.lastname}',
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/auth/user_profile.dart
+++ b/lib/features/auth/user_profile.dart
@@ -9,6 +9,7 @@ class UserProfile {
   final String phone;
   final String email;
   final String login;
+  final String avatarUrl;
   final bool isVerifiedPhone;
   final bool isVerifiedEmail;
   final bool isUaeResident;
@@ -23,6 +24,7 @@ class UserProfile {
     required this.phone,
     required this.email,
     required this.login,
+    required this.avatarUrl,
     required this.isVerifiedPhone,
     required this.isVerifiedEmail,
     required this.isUaeResident,
@@ -39,6 +41,8 @@ class UserProfile {
       phone: json['phone']?.toString() ?? '',
       email: json['email']?.toString() ?? '',
       login: json['login']?.toString() ?? '',
+      avatarUrl:
+          json['avatar_url']?.toString() ?? json['avatar']?.toString() ?? '',
       isVerifiedPhone: parseBool(json['is_verified_phone']),
       isVerifiedEmail: parseBool(json['is_verified_email']),
       isUaeResident: parseBool(json['is_uae_resident']),
@@ -56,6 +60,7 @@ class UserProfile {
       'phone': phone,
       'email': email,
       'login': login,
+      'avatar_url': avatarUrl,
       'is_verified_phone': isVerifiedPhone,
       'is_verified_email': isVerifiedEmail,
       'is_uae_resident': isUaeResident,

--- a/test/core/services/api_service_test.dart
+++ b/test/core/services/api_service_test.dart
@@ -54,6 +54,7 @@ void main() {
                 'is_verified_email': 1,
                 'is_uae_resident': 0,
                 'lang': 'en',
+                'avatar_url': 'https://example.com/avatar.png',
               },
             ),
           );
@@ -66,6 +67,7 @@ void main() {
     expect(profile.name, 'John');
     expect(profile.lastname, 'Doe');
     expect(profile.isVerifiedEmail, true);
+    expect(profile.avatarUrl, 'https://example.com/avatar.png');
 
     service.dio.interceptors.clear();
   });
@@ -97,6 +99,7 @@ void main() {
                 'is_verified_email': 0,
                 'is_uae_resident': 0,
                 'lang': 'en',
+                'avatar_url': 'https://example.com/avatar.png',
               },
             ),
           );


### PR DESCRIPTION
## Summary
- add avatarUrl to UserProfile and serialization
- show ProfileHeader with avatar and name in profile screen
- extend API service tests for avatar support

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be2788ab4c83269e3553282a7d276a