### PR TITLE
Add section headers and dividers in profile view

### DIFF
--- a/lib/features/auth/profile_screen.dart
+++ b/lib/features/auth/profile_screen.dart
@@ -250,39 +250,63 @@ class _ProfileScreenState extends State<ProfileScreen> {
         padding: const EdgeInsets.all(16),
         child: ProfileHeader(profile: profile),
       ),
-      Container(
-        decoration: BoxDecoration(
-          color: surface,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text('Личная информация'),
-            const Divider(),
-            buildTile('Имя', profile.name, Icons.person),
-            buildTile('Фамилия', profile.lastname, Icons.person),
-          ],
-        ),
+      Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              'Личная информация',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Container(
+            decoration: BoxDecoration(
+              color: surface,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                buildTile('Имя', profile.name, Icons.person),
+                buildTile('Фамилия', profile.lastname, Icons.person),
+              ],
+            ),
+          ),
+          const Divider(),
+        ],
       ),
-      Container(
-        decoration: BoxDecoration(
-          color: surface,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text('Контакты'),
-            const Divider(),
-            buildTile('Телефон', profile.phone, Icons.phone,
-                verified: profile.isVerifiedPhone),
-            buildTile('Email', profile.email, Icons.email,
-                verified: profile.isVerifiedEmail),
-          ],
-        ),
+      Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              'Контакты',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Container(
+            decoration: BoxDecoration(
+              color: surface,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                buildTile('Телефон', profile.phone, Icons.phone,
+                    verified: profile.isVerifiedPhone),
+                buildTile('Email', profile.email, Icons.email,
+                    verified: profile.isVerifiedEmail),
+              ],
+            ),
+          ),
+          const Divider(),
+        ],
       ),
       Container(
         decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- Add padded section headers for personal info and contacts
- Insert spacing and dividers separating each profile field block

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be34394b388326908fc5b307ce0090