### PR TITLE
Fix tab scroll controller retrieval in mClub screen

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -113,9 +113,10 @@ class _MClubScreenState extends State<MClubScreen> with TickerProviderStateMixin
       }
 
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _tabScrollController = Scrollable.of(
-          _tabBarKey.currentContext!,
-        )?.widget.controller;
+        final ctx = _tabKeys.isNotEmpty ? _tabKeys[0].currentContext : null;
+        if (ctx != null) {
+          _tabScrollController = Scrollable.of(ctx)?.widget.controller;
+        }
       });
     } catch (e, stack) {
       // Log the exception so debugging information is available in the console


### PR DESCRIPTION
## Summary
- avoid Scrollable.of error by getting scroll controller from first Tab instead of TabBar

## Testing
- `dart format lib/features/mclub/mclub_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c459bfcb648326b404c8c3d7f62279