### PR TITLE
Navigate to HomeScreen after email verification

### DIFF
--- a/lib/features/auth/auth_email_screen.dart
+++ b/lib/features/auth/auth_email_screen.dart
@@ -339,7 +339,10 @@ class _AuthCodeScreenState extends State<_AuthCodeScreen> {
       // После успешной верификации обновляем состояние авторизации
       // и возвращаемся к корневому экрану, где [AuthGate] покажет приложение.
       AuthGate.of(context)?.refreshAuthState();
-      Navigator.of(context).popUntil((route) => route.isFirst);
+      Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => const HomeScreen()),
+        (_) => false,
+      );
     } catch (e) {
       if (!mounted) return;
       final t = _L.of(context);


### PR DESCRIPTION
## Summary
- Redirect users to HomeScreen after verifying email code

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c566902df48326a52ed9f9d6f7a80e