### PR TITLE
Add nearby discounts bottom sheet

### DIFF
--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -6,6 +6,7 @@ import 'offer_detail_screen.dart';
 import 'offer_model.dart';
 import 'offers_map_screen.dart';
 import 'category_model.dart';
+import 'widgets/nearby_discounts_sheet.dart';
 
 class MClubScreen extends StatefulWidget {
   const MClubScreen({super.key, this.showNearbyOnly = false});
@@ -207,6 +208,28 @@ class _MClubScreenState extends State<MClubScreen>
     }
   }
 
+  void _showNearbyDiscountsSheet() {
+    final sorted = _offers
+        .where((o) => _minDistanceMeters(o['branches']) <= 300)
+        .toList()
+      ..sort(
+        (a, b) => _minDistanceMeters(a['branches'])
+            .compareTo(_minDistanceMeters(b['branches'])),
+      );
+    final nearby = sorted.take(3).toList();
+    if (nearby.isEmpty) return;
+    showModalBottomSheet(
+      context: context,
+      builder: (ctx) => NearbyDiscountsSheet(
+        offers: nearby,
+        onShowAll: () {
+          Navigator.pop(ctx);
+          setState(() => _nearbyOnly = true);
+        },
+      ),
+    );
+  }
+
   void _maybeShowNearbyHint() {
     if (_nearbyHintShown ||
         _curLat == null ||
@@ -224,34 +247,7 @@ class _MClubScreenState extends State<MClubScreen>
 
     Future.delayed(
       const Duration(seconds: 15),
-      () => showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          content: const Text(
-            'Рядом есть предложения. Показать их?',
-            style: TextStyle(color: Colors.black),
-          ),
-          actions: [
-            TextButton(
-              style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFF182857),
-              ),
-              onPressed: () {
-                Navigator.pop(context);
-                setState(() => _nearbyOnly = true);
-              },
-              child: const Text('Показать'),
-            ),
-            TextButton(
-              style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFF182857),
-              ),
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Отмена'),
-            ),
-          ],
-        ),
-      ),
+      _showNearbyDiscountsSheet,
     );
   }
 

--- a/lib/features/mclub/widgets/nearby_discounts_sheet.dart
+++ b/lib/features/mclub/widgets/nearby_discounts_sheet.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+class NearbyDiscountsSheet extends StatelessWidget {
+  final List<dynamic> offers;
+  final VoidCallback? onShowAll;
+
+  const NearbyDiscountsSheet({
+    super.key,
+    required this.offers,
+    this.onShowAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height * 0.33;
+    return SizedBox(
+      height: height,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                const Expanded(
+                  child: Text(
+                    'Рядом есть скидки!',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: ListView.separated(
+              itemCount: offers.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final offer = offers[index];
+                final photo = (offer['photo_url'] ?? '').toString();
+                final title = (offer['title'] ?? '').toString();
+                final benefit = (offer['benefit'] ?? '').toString();
+                return ListTile(
+                  leading: photo.isNotEmpty
+                      ? Image.network(
+                          photo,
+                          width: 56,
+                          height: 56,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) => Container(
+                            width: 56,
+                            height: 56,
+                            color: Colors.grey.shade200,
+                          ),
+                        )
+                      : Container(
+                          width: 56,
+                          height: 56,
+                          color: Colors.grey.shade200,
+                        ),
+                  title: Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    benefit,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                );
+              },
+            ),
+          ),
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: onShowAll,
+                      child: const Text('Показать все'),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Закрыть'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Show a custom bottom sheet when nearby discounts are detected
- Bottom sheet lists top three nearest offers and lets user show all

## Testing
- `dart format lib/features/mclub/mclub_screen.dart lib/features/mclub/widgets/nearby_discounts_sheet.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c569157f108326b3c77d3c61cc4bbe