### PR TITLE
refactor: remove dividers in discounts sheet

### DIFF
--- a/lib/features/mclub/widgets/nearby_discounts_sheet.dart
+++ b/lib/features/mclub/widgets/nearby_discounts_sheet.dart
@@ -46,11 +46,9 @@ class NearbyDiscountsSheet extends StatelessWidget {
               ],
             ),
           ),
-          const Divider(height: 1),
           Expanded(
-            child: ListView.separated(
+            child: ListView.builder(
               itemCount: offers.length,
-              separatorBuilder: (_, __) => const Divider(height: 1),
               itemBuilder: (context, index) {
                 final offer = offers[index];
                 final photo = (offer['photo_url'] ?? '').toString();


### PR DESCRIPTION
## Summary
- remove header divider from nearby discounts sheet
- switch to `ListView.builder` to drop item dividers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56db5af5083269f40c7436995dff6