### PR TITLE
Move profile access to app bar

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -30,7 +30,6 @@ class _HomeScreenState extends State<HomeScreen> {
       const UAEUnlockedScreen(),
       const RadioScreen(),
       const NewsScreen(),
-      const ProfileScreen(),
     ];
   }
 
@@ -40,6 +39,14 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         toolbarHeight: 52,                 // компактная шапка
         automaticallyImplyLeading: false,  // без пустой «назад»-кнопки
+        leading: IconButton(
+          icon: Icon(Icons.person, color: _primary),
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const ProfileScreen()),
+            );
+          },
+        ),
         backgroundColor: Colors.white,
         centerTitle: true,
         elevation: 0,
@@ -62,7 +69,6 @@ class _HomeScreenState extends State<HomeScreen> {
           BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Рекомендации'),
           BottomNavigationBarItem(icon: Icon(Icons.radio), label: 'Радио'),
           BottomNavigationBarItem(icon: Icon(Icons.article), label: 'Новости'),
-          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Профиль'),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- Open profile via leading AppBar button
- Remove profile page from HomeScreen tab navigation

## Testing
- `dart format lib/features/home/home_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f4c09d08326a9f51458dfbf08fc