### PR TITLE
Add News API service and models

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -1,0 +1,46 @@
+import 'dart:ui' as ui;
+import 'package:dio/dio.dart';
+import 'package:m_club/features/news/models/news_category.dart';
+
+class NewsApiService {
+  static final NewsApiService _instance = NewsApiService._internal();
+  factory NewsApiService() => _instance;
+  NewsApiService._internal() {
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: 'https://russianemirates.com/api/v4',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Language': _resolveLang(),
+        },
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ),
+    );
+  }
+
+  late Dio _dio;
+
+  /// Получить список новостных лент (feeds)
+  Future<List<NewsCategory>> fetchFeeds() async {
+    final res = await _dio.get('/news/feeds/');
+    final raw = res.data;
+    final data = raw is Map && raw['data'] is List ? raw['data'] : raw;
+
+    final categories = <NewsCategory>[];
+    if (data is List) {
+      for (final item in data) {
+        if (item is Map<String, dynamic>) {
+          categories.add(NewsCategory.fromJson(item));
+        }
+      }
+    }
+    return categories;
+  }
+
+  String _resolveLang() {
+    final code = ui.PlatformDispatcher.instance.locale.languageCode.toLowerCase();
+    return code == 'ru' ? 'ru' : 'en';
+  }
+}
+

--- a/lib/features/news/models/news_category.dart
+++ b/lib/features/news/models/news_category.dart
@@ -1,0 +1,30 @@
+import 'news_rubric.dart';
+
+class NewsCategory {
+  final String id;
+  final String name;
+  final List<NewsRubric> rubrics;
+
+  NewsCategory({
+    required this.id,
+    required this.name,
+    required this.rubrics,
+  });
+
+  factory NewsCategory.fromJson(Map<String, dynamic> json) {
+    final rubrics = <NewsRubric>[];
+    final rawRubrics = json['rubrics'];
+    if (rawRubrics is List) {
+      for (final r in rawRubrics) {
+        if (r is Map<String, dynamic>) {
+          rubrics.add(NewsRubric.fromJson(r));
+        }
+      }
+    }
+    return NewsCategory(
+      id: json['id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      rubrics: rubrics,
+    );
+  }
+}

--- a/lib/features/news/models/news_rubric.dart
+++ b/lib/features/news/models/news_rubric.dart
@@ -1,0 +1,19 @@
+class NewsRubric {
+  final String id;
+  final String name;
+  final String slug;
+
+  NewsRubric({
+    required this.id,
+    required this.name,
+    required this.slug,
+  });
+
+  factory NewsRubric.fromJson(Map<String, dynamic> json) {
+    return NewsRubric(
+      id: json['id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      slug: json['slug']?.toString() ?? '',
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add NewsApiService for russianemirates.com feeds
- create NewsCategory and NewsRubric models

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b06af3488326beb6d34888f3aa99