### PR TITLE
Add category-based tabs to news screen

### DIFF
--- a/lib/features/news/news_category_screen.dart
+++ b/lib/features/news/news_category_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import 'models/news_category.dart';
+
+class NewsCategoryScreen extends StatelessWidget {
+  const NewsCategoryScreen({super.key, required this.category});
+
+  final NewsCategory category;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(category.name)),
+      body: Center(child: Text('Категория: ${category.name}')),
+    );
+  }
+}

--- a/lib/features/news/news_screen.dart
+++ b/lib/features/news/news_screen.dart
@@ -1,9 +1,66 @@
 import 'package:flutter/material.dart';
 
-class NewsScreen extends StatelessWidget {
+import '../../core/services/news_api_service.dart';
+import 'models/news_category.dart';
+import 'news_category_screen.dart';
+
+class NewsScreen extends StatefulWidget {
   const NewsScreen({super.key});
+
+  @override
+  State<NewsScreen> createState() => _NewsScreenState();
+}
+
+class _NewsScreenState extends State<NewsScreen> {
+  final _api = NewsApiService();
+  List<NewsCategory> _categories = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCategories();
+  }
+
+  Future<void> _loadCategories() async {
+    final cats = await _api.fetchFeeds();
+    if (mounted) {
+      setState(() => _categories = cats);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text('Новости из ОАЭ: ленты'));
+    if (_categories.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return DefaultTabController(
+      length: _categories.length + 1,
+      child: Column(
+        children: [
+          TabBar(
+            isScrollable: true,
+            tabs: [
+              const Tab(text: 'Все новости'),
+              for (final cat in _categories) Tab(text: cat.name),
+            ],
+            onTap: (index) {
+              if (index == 0) return;
+              final category = _categories[index - 1];
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => NewsCategoryScreen(category: category),
+                ),
+              );
+            },
+          ),
+          const Expanded(
+            child: Center(
+              child: Text('Новости из ОАЭ: ленты'),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Load news categories via `NewsApiService.fetchFeeds` and show a tab for each
- Add navigation to a new `NewsCategoryScreen` when selecting a category

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b1e3cae08326b9309ef06071513d