### PR TITLE
feat: add news category screen with tabs

### DIFF
--- a/lib/features/news/news_category_screen.dart
+++ b/lib/features/news/news_category_screen.dart
@@ -9,9 +9,26 @@ class NewsCategoryScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(category.name)),
-      body: Center(child: Text('Категория: ${category.name}')),
+    return DefaultTabController(
+      length: category.rubrics.length,
+      child: Scaffold(
+        appBar: AppBar(
+          leading: const BackButton(),
+          title: Text(category.name),
+          bottom: TabBar(
+            isScrollable: true,
+            tabs: [
+              for (final rubric in category.rubrics) Tab(text: rubric.name),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            for (final _ in category.rubrics)
+              const Center(child: Text('Список новостей')),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add NewsCategoryScreen with rubric-based tabs and placeholder TabBarView
- ensure navigation flows from NewsScreen to NewsCategoryScreen

## Testing
- `dart format lib/features/news/news_category_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b62ef010832697cec18cf25d3978