### PR TITLE
Handle loading and error states for news categories

### DIFF
--- a/lib/features/news/news_screen.dart
+++ b/lib/features/news/news_screen.dart
@@ -14,6 +14,8 @@ class NewsScreen extends StatefulWidget {
 class _NewsScreenState extends State<NewsScreen> {
   final _api = NewsApiService();
   List<NewsCategory> _categories = [];
+  bool _isLoading = true;
+  String? _error;
 
   @override
   void initState() {
@@ -22,16 +24,38 @@ class _NewsScreenState extends State<NewsScreen> {
   }
 
   Future<void> _loadCategories() async {
-    final cats = await _api.fetchFeeds();
-    if (mounted) {
-      setState(() => _categories = cats);
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final cats = await _api.fetchFeeds();
+      if (mounted) {
+        setState(() => _categories = cats);
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _error = 'Ошибка загрузки');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      } else {
+        _isLoading = false;
+      }
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_categories.isEmpty) {
+    if (_isLoading) {
       return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_categories.isEmpty) {
+      return Center(
+        child: Text(_error ?? 'Нет данных'),
+      );
     }
 
     return DefaultTabController(


### PR DESCRIPTION
## Summary
- add loading flag with error state for news categories
- show progress indicator only while loading, otherwise show error/no data message
- wrap feed fetching in try/catch to handle API errors

## Testing
- `flutter format lib/features/news/news_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b81241948326ad24504adf1d83ec