### PR TITLE
Handle Map response for news feeds

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -34,6 +34,12 @@ class NewsApiService {
           categories.add(NewsCategory.fromJson(item));
         }
       }
+    } else if (data is Map) {
+      for (final item in data.values) {
+        if (item is Map<String, dynamic>) {
+          categories.add(NewsCategory.fromJson(item));
+        }
+      }
     }
     return categories;
   }


### PR DESCRIPTION
## Summary
- Parse map responses in `NewsApiService.fetchFeeds`

## Testing
- `dart format lib/core/services/news_api_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba2361fc83268a483faabcf50892