### PR TITLE
feat(news): add NewsItem model

### DIFF
--- a/lib/features/news/models/news_item.dart
+++ b/lib/features/news/models/news_item.dart
@@ -1,0 +1,54 @@
+import 'news_rubric.dart';
+
+class NewsItem {
+  final String id;
+  final String title;
+  final String contentPreview;
+  final String contentFull;
+  final String image;
+  final String url;
+  final String author;
+  final DateTime? published;
+  final NewsRubric? rubric;
+
+  NewsItem({
+    required this.id,
+    required this.title,
+    required this.contentPreview,
+    required this.contentFull,
+    required this.image,
+    required this.url,
+    required this.author,
+    this.published,
+    this.rubric,
+  });
+
+  factory NewsItem.fromJson(Map<String, dynamic> json) {
+    NewsRubric? rubric;
+    final r = json['rubric'];
+    if (r is Map<String, dynamic>) {
+      rubric = NewsRubric.fromJson(r);
+    }
+
+    DateTime? published;
+    final p = json['published'] ?? json['published_at'] ?? json['date'];
+    if (p != null) {
+      published = DateTime.tryParse(p.toString());
+    }
+
+    return NewsItem(
+      id: json['id']?.toString() ?? '',
+      title: json['title']?.toString() ?? '',
+      contentPreview: (json['content_preview'] ?? json['preview'] ?? json['introtext'] ?? json['short_content'] ?? '')
+          .toString(),
+      contentFull:
+          (json['content_full'] ?? json['content'] ?? json['fulltext'] ?? json['full_text'] ?? '').toString(),
+      image: (json['image'] ?? json['image_url'] ?? json['photo_url'] ?? '').toString(),
+      url: (json['url'] ?? json['link'] ?? '').toString(),
+      author: (json['author'] ?? '').toString(),
+      published: published,
+      rubric: rubric,
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add NewsItem model with fields and fromJson parsing

## Testing
- `flutter test` (fails: command not found)
- `dart test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c5cc434c448326a498a5d818be45fc