### PR TITLE
Add paginated news fetching to NewsApiService

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -1,6 +1,8 @@
 import 'dart:ui' as ui;
 import 'package:dio/dio.dart';
 import 'package:m_club/features/news/models/news_category.dart';
+import 'package:m_club/features/news/models/news_item.dart';
+import 'package:m_club/features/news/models/news_page.dart';
 
 class NewsApiService {
   static final NewsApiService _instance = NewsApiService._internal();
@@ -42,6 +44,48 @@ class NewsApiService {
       }
     }
     return categories;
+  }
+
+  /// Получить список новостей
+  Future<NewsPage> fetchNews({
+    int page = 1,
+    int perPage = 20,
+    String? categoryId,
+  }) async {
+    final params = {
+      'page': page,
+      'per-page': perPage,
+    };
+    if (categoryId != null) {
+      params['category_id'] = categoryId;
+    }
+
+    final res = await _dio.get('/news/', queryParameters: params);
+    final raw = res.data;
+    final data = raw is Map && raw['data'] is Map ? raw['data'] : raw;
+
+    final rawItems = data is Map && data['items'] is List
+        ? data['items']
+        : (data is List ? data : []);
+    final items = <NewsItem>[];
+    if (rawItems is List) {
+      for (final item in rawItems) {
+        if (item is Map<String, dynamic>) {
+          items.add(NewsItem.fromJson(item));
+        }
+      }
+    }
+
+    final pageNum =
+        data is Map && data['page'] is num ? (data['page'] as num).toInt() : page;
+    final pages = data is Map && data['pages'] is num
+        ? (data['pages'] as num).toInt()
+        : 1;
+    final total = data is Map && data['total'] is num
+        ? (data['total'] as num).toInt()
+        : items.length;
+
+    return NewsPage(items: items, page: pageNum, pages: pages, total: total);
   }
 
   String _resolveLang() {

--- a/lib/features/news/models/news_page.dart
+++ b/lib/features/news/models/news_page.dart
@@ -1,0 +1,16 @@
+import 'news_item.dart';
+
+class NewsPage {
+  final List<NewsItem> items;
+  final int page;
+  final int pages;
+  final int total;
+
+  NewsPage({
+    required this.items,
+    required this.page,
+    required this.pages,
+    required this.total,
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `fetchNews` to `NewsApiService` with pagination and category filtering
- create `NewsPage` model to hold items and pagination metadata

## Testing
- `dart format lib/core/services/news_api_service.dart lib/features/news/models/news_page.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cd42098c8326a898726892a61df6