### PR TITLE
feat: allow mixed param types in news API service

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -52,7 +52,7 @@ class NewsApiService {
     int perPage = 20,
     String? categoryId,
   }) async {
-    final params = {
+    final params = <String, dynamic>{
       'page': page,
       'per-page': perPage,
     };


### PR DESCRIPTION
## Summary
- type params map to allow mixed types in news API requests

## Testing
- `flutter analyze` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cf39554c832689ee159073ade71c