### PR TITLE
Add rubric-specific news lists with refresh and retry

### DIFF
--- a/lib/features/news/news_category_screen.dart
+++ b/lib/features/news/news_category_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'models/news_category.dart';
+import 'news_list.dart';
 
 class NewsCategoryScreen extends StatelessWidget {
   const NewsCategoryScreen({super.key, required this.category});
@@ -24,8 +25,8 @@ class NewsCategoryScreen extends StatelessWidget {
         ),
         body: TabBarView(
           children: [
-            for (final _ in category.rubrics)
-              const Center(child: Text('Список новостей')),
+            for (final rubric in category.rubrics)
+              NewsList(categoryId: rubric.id),
           ],
         ),
       ),

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+
+import '../../core/services/news_api_service.dart';
+import 'models/news_item.dart';
+
+class NewsList extends StatefulWidget {
+  const NewsList({super.key, this.categoryId});
+
+  final String? categoryId;
+
+  @override
+  State<NewsList> createState() => _NewsListState();
+}
+
+class _NewsListState extends State<NewsList> {
+  final _api = NewsApiService();
+  final _scrollController = ScrollController();
+  final List<NewsItem> _items = [];
+  bool _isLoading = false;
+  String? _error;
+  int _page = 1;
+  int _pages = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMore();
+    _scrollController.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      _loadMore();
+    }
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _items.clear();
+      _page = 1;
+      _pages = 1;
+      _error = null;
+    });
+    await _loadMore();
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || _page > _pages) return;
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final page = await _api.fetchNews(
+        page: _page,
+        categoryId: widget.categoryId,
+      );
+      setState(() {
+        _items.addAll(page.items);
+        _page = page.page + 1;
+        _pages = page.pages;
+      });
+    } catch (e) {
+      setState(() {
+        _error = 'Ошибка загрузки';
+      });
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      } else {
+        _isLoading = false;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_items.isEmpty) {
+      if (_isLoading) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      if (_error != null) {
+        return Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _loadMore,
+                child: const Text('Повторить'),
+              ),
+            ],
+          ),
+        );
+      }
+    }
+
+    final showBottom = _isLoading || _error != null;
+
+    return RefreshIndicator(
+      onRefresh: _refresh,
+      child: ListView.builder(
+        controller: _scrollController,
+        itemCount: _items.length + (showBottom ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index >= _items.length) {
+            if (_isLoading) {
+              return const Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Center(child: CircularProgressIndicator()),
+              );
+            } else {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(_error ?? 'Ошибка'),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _loadMore,
+                      child: const Text('Повторить'),
+                    ),
+                  ],
+                ),
+              );
+            }
+          }
+          final item = _items[index];
+          return ListTile(
+            title: Text(item.title),
+            subtitle: item.published != null
+                ? Text(item.published!.toLocal().toString())
+                : null,
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/features/news/news_screen.dart
+++ b/lib/features/news/news_screen.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../../core/services/news_api_service.dart';
 import 'models/news_category.dart';
-import 'models/news_item.dart';
 import 'news_category_screen.dart';
+import 'news_list.dart';
 
 class NewsScreen extends StatefulWidget {
   const NewsScreen({super.key});
@@ -84,110 +84,6 @@ class _NewsScreenState extends State<NewsScreen> {
           ),
         ],
       ),
-    );
-  }
-}
-
-class NewsList extends StatefulWidget {
-  const NewsList({super.key});
-
-  @override
-  State<NewsList> createState() => _NewsListState();
-}
-
-class _NewsListState extends State<NewsList> {
-  final _api = NewsApiService();
-  final _scrollController = ScrollController();
-  final List<NewsItem> _items = [];
-  bool _isLoading = false;
-  String? _error;
-  int _page = 1;
-  int _pages = 1;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadMore();
-    _scrollController.addListener(_onScroll);
-  }
-
-  void _onScroll() {
-    if (_scrollController.position.pixels >=
-        _scrollController.position.maxScrollExtent - 200) {
-      _loadMore();
-    }
-  }
-
-  Future<void> _loadMore() async {
-    if (_isLoading || _page > _pages) return;
-    setState(() {
-      _isLoading = true;
-      _error = null;
-    });
-    try {
-      final page = await _api.fetchNews(page: _page);
-      setState(() {
-        _items.addAll(page.items);
-        _page = page.page + 1;
-        _pages = page.pages;
-      });
-    } catch (e) {
-      setState(() {
-        _error = 'Ошибка загрузки';
-      });
-    } finally {
-      if (mounted) {
-        setState(() => _isLoading = false);
-      } else {
-        _isLoading = false;
-      }
-    }
-  }
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_items.isEmpty) {
-      if (_isLoading) {
-        return const Center(child: CircularProgressIndicator());
-      }
-      if (_error != null) {
-        return Center(child: Text(_error!));
-      }
-    }
-
-    final showBottom = _isLoading || _error != null;
-
-    return ListView.builder(
-      controller: _scrollController,
-      itemCount: _items.length + (showBottom ? 1 : 0),
-      itemBuilder: (context, index) {
-        if (index >= _items.length) {
-          if (_isLoading) {
-            return const Padding(
-              padding: EdgeInsets.symmetric(vertical: 16),
-              child: Center(child: CircularProgressIndicator()),
-            );
-          } else {
-            return Padding(
-              padding: const EdgeInsets.symmetric(vertical: 16),
-              child: Center(child: Text(_error ?? 'Ошибка')),
-            );
-          }
-        }
-        final item = _items[index];
-        return ListTile(
-          title: Text(item.title),
-          subtitle: item.published != null
-              ? Text(item.published!.toLocal().toString())
-              : null,
-        );
-      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Embed `NewsList` per rubric in `NewsCategoryScreen`
- Extract `NewsList` widget with optional `categoryId`
- Add pull-to-refresh and retry handling for news loading

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d21e34cc832699ad43de48c98fc2