### PR TITLE
Fix news API path strings

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -25,7 +25,7 @@ class NewsApiService {
 
   /// Получить список новостных лент (feeds)
   Future<List<NewsCategory>> fetchFeeds() async {
-    final res = await _dio.get('/news/feeds/');
+    final res = await _dio.get('news/feeds/');
     final raw = res.data;
     final data = raw is Map && raw['data'] is List ? raw['data'] : raw;
 
@@ -60,7 +60,7 @@ class NewsApiService {
       params['category_id'] = categoryId;
     }
 
-    final res = await _dio.get('/news/', queryParameters: params);
+    final res = await _dio.get('news/', queryParameters: params);
     final raw = res.data;
     final data = raw is Map && raw['data'] is Map ? raw['data'] : raw;
 


### PR DESCRIPTION
## Summary
- remove leading slash from news API feed and news endpoints

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d6373198832695fb98cf19b7791b