### PR TITLE
Skip empty category filter in news API requests

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -52,11 +52,8 @@ class NewsApiService {
     int perPage = 20,
     String? categoryId,
   }) async {
-    final params = <String, dynamic>{
-      'page': page,
-      'per-page': perPage,
-    };
-    if (categoryId != null) {
+    final params = <String, dynamic>{'page': page, 'per-page': perPage};
+    if (categoryId?.isNotEmpty ?? false) {
       params['category_id'] = categoryId;
     }
 
@@ -76,8 +73,9 @@ class NewsApiService {
       }
     }
 
-    final pageNum =
-        data is Map && data['page'] is num ? (data['page'] as num).toInt() : page;
+    final pageNum = data is Map && data['page'] is num
+        ? (data['page'] as num).toInt()
+        : page;
     final pages = data is Map && data['pages'] is num
         ? (data['pages'] as num).toInt()
         : 1;
@@ -89,8 +87,8 @@ class NewsApiService {
   }
 
   String _resolveLang() {
-    final code = ui.PlatformDispatcher.instance.locale.languageCode.toLowerCase();
+    final code = ui.PlatformDispatcher.instance.locale.languageCode
+        .toLowerCase();
     return code == 'ru' ? 'ru' : 'en';
   }
 }
-


### PR DESCRIPTION
## Summary
- avoid sending `category_id` when the id is null or empty in `NewsApiService.fetchNews`

## Testing
- `dart /tmp/test_params.dart`
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c5db308048832694aab1df1d9dc92a