### PR TITLE
feat: auto-load news on scroll

### DIFF
--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -29,8 +29,7 @@ class _NewsListState extends State<NewsList> {
   }
 
   void _onScroll() {
-    if (_scrollController.position.pixels >=
-        _scrollController.position.maxScrollExtent - 200) {
+    if (_scrollController.position.extentAfter < 200) {
       _loadMore();
     }
   }


### PR DESCRIPTION
## Summary
- trigger additional news fetches when the scroll position nears the list's end

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c5df9d347c8326ac4a659bc4116779