### PR TITLE
Parse pagination metadata in news API service

### DIFF
--- a/test/core/services/news_api_service_test.dart
+++ b/test/core/services/news_api_service_test.dart
@@ -1,0 +1,78 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_club/core/services/news_api_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final service = NewsApiService();
+
+  setUp(() {
+    service.dio.interceptors.clear();
+  });
+
+  tearDown(() {
+    service.dio.interceptors.clear();
+  });
+
+  test('fetchNews parses items and pagination', () async {
+    service.dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              data: {
+                'data': [
+                  {'id': 1, 'title': 'First'},
+                  {'id': 2, 'title': 'Second'},
+                ],
+                'pagination': {
+                  'page': 2,
+                  'perPage': 10,
+                  'total': 20,
+                  'pages': 2,
+                },
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    final page = await service.fetchNews(page: 2, perPage: 10);
+    expect(page.items, hasLength(2));
+    expect(page.page, 2);
+    expect(page.total, 20);
+    expect(page.pages, 2);
+  });
+
+  test('fetchNews computes pages when missing', () async {
+    service.dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              data: {
+                'data': [
+                  {'id': 1, 'title': 'Only'},
+                ],
+                'pagination': {
+                  'page': 1,
+                  'perPage': 8,
+                  'total': 15,
+                },
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    final page = await service.fetchNews(page: 1, perPage: 8);
+    expect(page.items, hasLength(1));
+    expect(page.page, 1);
+    expect(page.total, 15);
+    expect(page.pages, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- Parse `data` in news API responses as a list of news maps
- Extract pagination metadata and compute `pages` when missing
- Add tests covering pagination parsing and fallback

## Testing
- `flutter test test/core/services/news_api_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e32c60548326b5bd23c3761be4ae