### PR TITLE
Handle string pagination values in NewsApiService

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -77,18 +77,34 @@ class NewsApiService {
     final pagination = raw is Map && raw['pagination'] is Map
         ? raw['pagination'] as Map
         : const {};
-    final pageNum = pagination['page'] is num
-        ? (pagination['page'] as num).toInt()
-        : page;
-    final perPageVal = pagination['perPage'] is num
-        ? (pagination['perPage'] as num).toInt()
-        : perPage;
-    final total = pagination['total'] is num
-        ? (pagination['total'] as num).toInt()
-        : items.length;
-    int? pages = pagination['pages'] is num
-        ? (pagination['pages'] as num).toInt()
-        : null;
+
+    final pageRaw = pagination['page'];
+    final pageNum = pageRaw is num
+        ? pageRaw.toInt()
+        : pageRaw is String
+            ? int.tryParse(pageRaw) ?? page
+            : page;
+
+    final perPageRaw = pagination['perPage'];
+    final perPageVal = perPageRaw is num
+        ? perPageRaw.toInt()
+        : perPageRaw is String
+            ? int.tryParse(perPageRaw) ?? perPage
+            : perPage;
+
+    final totalRaw = pagination['total'];
+    final total = totalRaw is num
+        ? totalRaw.toInt()
+        : totalRaw is String
+            ? int.tryParse(totalRaw) ?? items.length
+            : items.length;
+
+    final pagesRaw = pagination['pages'];
+    int? pages = pagesRaw is num
+        ? pagesRaw.toInt()
+        : pagesRaw is String
+            ? int.tryParse(pagesRaw)
+            : null;
     pages ??= (total / perPageVal).ceil();
 
     return NewsPage(items: items, page: pageNum, pages: pages, total: total);

--- a/test/core/services/news_api_service_test.dart
+++ b/test/core/services/news_api_service_test.dart
@@ -46,6 +46,38 @@ void main() {
     expect(page.pages, 2);
   });
 
+  test('fetchNews parses pagination when numbers are strings', () async {
+    service.dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              data: {
+                'data': [
+                  {'id': 1, 'title': 'First'},
+                  {'id': 2, 'title': 'Second'},
+                ],
+                'pagination': {
+                  'page': '2',
+                  'perPage': '10',
+                  'total': '20',
+                  'pages': '2',
+                },
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    final page = await service.fetchNews(page: 2, perPage: 10);
+    expect(page.items, hasLength(2));
+    expect(page.page, 2);
+    expect(page.total, 20);
+    expect(page.pages, 2);
+  });
+
   test('fetchNews computes pages when missing', () async {
     service.dio.interceptors.add(
       InterceptorsWrapper(


### PR DESCRIPTION
## Summary
- parse `page`, `perPage`, `total`, and `pages` from strings in `NewsApiService.fetchNews`
- test pagination parsing when numeric values are provided as strings

## Testing
- `flutter analyze`
- `flutter test` *(fails: type '_Map<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>?', and several other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e68901cc8326981dd02b0d12353e