### PR TITLE
feat: add aggregated tab to news categories

### DIFF
--- a/lib/features/news/news_category_screen.dart
+++ b/lib/features/news/news_category_screen.dart
@@ -11,7 +11,7 @@ class NewsCategoryScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: category.rubrics.length,
+      length: category.rubrics.length + 1,
       child: Scaffold(
         appBar: AppBar(
           leading: const BackButton(),
@@ -19,12 +19,14 @@ class NewsCategoryScreen extends StatelessWidget {
           bottom: TabBar(
             isScrollable: true,
             tabs: [
+              const Tab(text: 'Все'),
               for (final rubric in category.rubrics) Tab(text: rubric.name),
             ],
           ),
         ),
         body: TabBarView(
           children: [
+            NewsList(categoryId: category.id),
             for (final rubric in category.rubrics)
               NewsList(categoryId: rubric.id),
           ],

--- a/test/core/services/news_api_service_test.dart
+++ b/test/core/services/news_api_service_test.dart
@@ -107,4 +107,34 @@ void main() {
     expect(page.total, 15);
     expect(page.pages, 2);
   });
+
+  test('fetchNews sends category id when provided', () async {
+    String? passedCategoryId;
+    service.dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          passedCategoryId = options.queryParameters['category_id']?.toString();
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              data: {
+                'data': [
+                  {'id': 1, 'title': 'Only'},
+                ],
+                'pagination': {
+                  'page': 1,
+                  'perPage': 10,
+                  'total': 1,
+                  'pages': 1,
+                },
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    await service.fetchNews(categoryId: 'cat123');
+    expect(passedCategoryId, 'cat123');
+  });
 }


### PR DESCRIPTION
## Summary
- show "Все" tab in category view aggregating all rubrics
- test that `fetchNews` forwards `category_id` parameter

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c5eb3bc1ac832694eba3de506da0a7