### PR TITLE
feat: add time ago helper for news

### DIFF
--- a/lib/core/utils/time_ago.dart
+++ b/lib/core/utils/time_ago.dart
@@ -1,0 +1,51 @@
+import 'package:intl/intl.dart';
+
+String timeAgo(dynamic input) {
+  DateTime date;
+  if (input is DateTime) {
+    date = input;
+  } else if (input is int) {
+    date = DateTime.fromMillisecondsSinceEpoch(
+      input < 1000000000000 ? input * 1000 : input,
+    );
+  } else if (input is double) {
+    final ms = input < 1000000000000 ? (input * 1000).toInt() : input.toInt();
+    date = DateTime.fromMillisecondsSinceEpoch(ms);
+  } else {
+    throw ArgumentError('Unsupported input type');
+  }
+
+  final now = DateTime.now();
+  final diff = now.difference(date);
+
+  if (diff.inDays >= 7) {
+    return DateFormat('dd.MM.yyyy', 'ru').format(date);
+  } else if (diff.inDays >= 1) {
+    final days = diff.inDays;
+    return '$days ${_plural(days, 'день', 'дня', 'дней')} назад';
+  } else if (diff.inHours >= 1) {
+    final hours = diff.inHours;
+    return '$hours ${_plural(hours, 'час', 'часа', 'часов')} назад';
+  } else {
+    final minutes = diff.inMinutes;
+    return '$minutes ${_plural(minutes, 'минута', 'минуты', 'минут')} назад';
+  }
+}
+
+String _plural(int number, String one, String few, String many) {
+  final n = number % 100;
+  if (n >= 11 && n <= 14) {
+    return many;
+  }
+  switch (number % 10) {
+    case 1:
+      return one;
+    case 2:
+    case 3:
+    case 4:
+      return few;
+    default:
+      return many;
+  }
+}
+

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
-
 import '../../core/services/news_api_service.dart';
+import '../../core/utils/time_ago.dart';
 import 'models/news_item.dart';
 
 class NewsList extends StatefulWidget {
@@ -190,7 +189,7 @@ class NewsListItem extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(top: 4),
                     child: Text(
-                      DateFormat('dd.MM.yyyy').format(item.published!),
+                      timeAgo(item.published),
                       style: const TextStyle(
                         fontSize: 14,
                         color: Colors.grey,


### PR DESCRIPTION
## Summary
- add `timeAgo` utility with russian plural support
- show relative published time in news list

## Testing
- `dart format lib/core/utils/time_ago.dart lib/features/news/news_list.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f755d5948326a95d5b4049da22f0