### PR TITLE
Add news detail screen

### DIFF
--- a/lib/features/news/news_detail_screen.dart
+++ b/lib/features/news/news_detail_screen.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../core/utils/image_brightness.dart';
+import '../../core/utils/time_ago.dart';
+import 'models/news_item.dart';
+
+class NewsDetailScreen extends StatefulWidget {
+  final NewsItem item;
+  const NewsDetailScreen({super.key, required this.item});
+
+  @override
+  State<NewsDetailScreen> createState() => _NewsDetailScreenState();
+}
+
+class _NewsDetailScreenState extends State<NewsDetailScreen> {
+  final _scrollController = ScrollController();
+  bool _collapsed = false;
+  bool? _isPhotoDark;
+
+  static const double _expandedHeight = 320;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    _analyzePhoto();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!mounted) return;
+    final topPad = MediaQuery.of(context).padding.top;
+    final threshold = _expandedHeight - (kToolbarHeight + topPad);
+    final nowCollapsed =
+        _scrollController.positions.isNotEmpty &&
+        _scrollController.offset >= threshold;
+    if (nowCollapsed != _collapsed) {
+      setState(() => _collapsed = nowCollapsed);
+    }
+  }
+
+  Future<void> _analyzePhoto() async {
+    final url = widget.item.image;
+    if (url.isEmpty) return;
+    final dark = await isImageDark(url);
+    if (mounted) setState(() => _isPhotoDark = dark);
+  }
+
+  void _share() {
+    final link = widget.item.url;
+    final title = widget.item.title;
+    final text = [title, link].where((e) => e.trim().isNotEmpty).join('\n');
+    if (text.isNotEmpty) Share.share(text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final dark = _isPhotoDark ?? true;
+    final iconColor =
+        _collapsed ? Colors.black87 : (dark ? Colors.white : Colors.black87);
+    final overlayStyle = _collapsed
+        ? SystemUiOverlayStyle.dark
+        : (dark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark);
+
+    final descPlain = item.contentPreview
+        .replaceAll(RegExp(r'<[^>]*>'), ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+
+    final meta = [
+      if (item.published != null) timeAgo(item.published),
+      if (item.author.trim().isNotEmpty) item.author.trim(),
+    ].join(' · ');
+
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: overlayStyle,
+      child: Scaffold(
+        body: CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            SliverAppBar(
+              backgroundColor: Colors.white,
+              elevation: 0,
+              pinned: true,
+              expandedHeight: _expandedHeight,
+              leading: IconButton(
+                icon: Icon(Icons.arrow_back, color: iconColor),
+                onPressed: () => Navigator.of(context).pop(),
+                tooltip: 'Назад',
+              ),
+              actions: [
+                IconButton(
+                  icon: Icon(Icons.share, color: iconColor),
+                  onPressed: _share,
+                  tooltip: 'Поделиться',
+                ),
+              ],
+              systemOverlayStyle: overlayStyle,
+              flexibleSpace: FlexibleSpaceBar(
+                background: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    if (item.image.isEmpty)
+                      Container(color: Colors.grey.shade200)
+                    else
+                      Image.network(
+                        item.image,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) =>
+                            Container(color: Colors.grey.shade200),
+                      ),
+                    Positioned.fill(
+                      child: IgnorePointer(
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.topCenter,
+                              end: Alignment.bottomCenter,
+                              colors: [
+                                Colors.transparent,
+                                Colors.black.withOpacity(0.1),
+                                Colors.black.withOpacity(0.3),
+                                Colors.black.withOpacity(0.5),
+                              ],
+                              stops: const [0.5, 0.75, 0.9, 1.0],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      left: 12,
+                      right: 12,
+                      bottom: 12,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (item.rubric != null &&
+                              item.rubric!.name.isNotEmpty)
+                            Text(
+                              item.rubric!.name.toUpperCase(),
+                              style: const TextStyle(
+                                color: Colors.white70,
+                                fontSize: 12,
+                                fontWeight: FontWeight.w500,
+                                shadows: [
+                                  Shadow(
+                                    color: Colors.black54,
+                                    blurRadius: 4,
+                                    offset: Offset(0, 1),
+                                  )
+                                ],
+                              ),
+                            ),
+                          Text(
+                            item.title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 22,
+                              fontWeight: FontWeight.w600,
+                              height: 1.2,
+                              shadows: [
+                                Shadow(
+                                  color: Colors.black54,
+                                  blurRadius: 4,
+                                  offset: Offset(0, 1),
+                                )
+                              ],
+                            ),
+                          ),
+                          if (descPlain.isNotEmpty) ...[
+                            const SizedBox(height: 8),
+                            Text(
+                              descPlain,
+                              maxLines: 3,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 16,
+                                height: 1.25,
+                                shadows: [
+                                  Shadow(
+                                    color: Colors.black54,
+                                    blurRadius: 4,
+                                    offset: Offset(0, 1),
+                                  )
+                                ],
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (meta.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 12),
+                        child: Text(
+                          meta,
+                          style: const TextStyle(
+                            fontSize: 14,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ),
+                    Html(data: item.contentFull),
+                  ],
+                ),
+              ),
+            ),
+            const SliverPadding(padding: EdgeInsets.only(bottom: 24)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -3,6 +3,7 @@ import '../../core/services/news_api_service.dart';
 import '../../core/utils/time_ago.dart';
 import 'models/news_item.dart';
 import 'package:share_plus/share_plus.dart';
+import 'news_detail_screen.dart';
 
 class NewsList extends StatefulWidget {
   const NewsList({super.key, this.categoryId});
@@ -141,7 +142,16 @@ class _NewsListState extends State<NewsList> {
             }
           }
           final item = _items[index];
-          return NewsListItem(item: item);
+          return NewsListItem(
+            item: item,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => NewsDetailScreen(item: item),
+                ),
+              );
+            },
+          );
         },
       ),
     );

--- a/test/features/news/news_detail_screen_test.dart
+++ b/test/features/news/news_detail_screen_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_club/features/news/models/news_item.dart';
+import 'package:m_club/features/news/news_detail_screen.dart';
+
+void main() {
+  testWidgets('shows title and content', (tester) async {
+    final item = NewsItem(
+      id: '1',
+      title: 'Test title',
+      contentPreview: 'Preview',
+      contentFull: '<p>Full text</p>',
+      image: '',
+      url: 'https://example.com',
+      author: 'Author',
+      published: DateTime(2024, 1, 1),
+      rubric: null,
+    );
+
+    await tester.pumpWidget(MaterialApp(home: NewsDetailScreen(item: item)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Test title'), findsOneWidget);
+    expect(find.text('Full text'), findsOneWidget);
+    expect(find.byIcon(Icons.share), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add detailed news page styled like offers with large image header and share option
- open news details from list items
- add basic widget test for news details

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fdbf4a748326bb72ec274a35cbeb