### PR TITLE
Add paginated news detail pager

### DIFF
--- a/lib/features/news/news_article_view.dart
+++ b/lib/features/news/news_article_view.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../core/utils/image_brightness.dart';
+import '../../core/utils/time_ago.dart';
+import 'models/news_item.dart';
+
+class NewsArticleView extends StatefulWidget {
+  const NewsArticleView({super.key, required this.item});
+
+  final NewsItem item;
+
+  @override
+  State<NewsArticleView> createState() => _NewsArticleViewState();
+}
+
+class _NewsArticleViewState extends State<NewsArticleView> {
+  final _scrollController = ScrollController();
+  bool _collapsed = false;
+  bool? _isPhotoDark;
+
+  static const double _expandedHeight = 320;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    _analyzePhoto();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!mounted) return;
+    final topPad = MediaQuery.of(context).padding.top;
+    final threshold = _expandedHeight - (kToolbarHeight + topPad);
+    final nowCollapsed =
+        _scrollController.positions.isNotEmpty &&
+            _scrollController.offset >= threshold;
+    if (nowCollapsed != _collapsed) {
+      setState(() => _collapsed = nowCollapsed);
+    }
+  }
+
+  Future<void> _analyzePhoto() async {
+    final url = widget.item.image;
+    if (url.isEmpty) return;
+    final dark = await isImageDark(url);
+    if (mounted) setState(() => _isPhotoDark = dark);
+  }
+
+  void _share() {
+    final link = widget.item.url;
+    final title = widget.item.title;
+    final text = [title, link].where((e) => e.trim().isNotEmpty).join('\n');
+    if (text.isNotEmpty) Share.share(text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final dark = _isPhotoDark ?? true;
+    final iconColor =
+        _collapsed ? Colors.black87 : (dark ? Colors.white : Colors.black87);
+    final overlayStyle = _collapsed
+        ? SystemUiOverlayStyle.dark
+        : (dark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark);
+
+    final descPlain = item.contentPreview
+        .replaceAll(RegExp(r'<[^>]*>'), ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+
+    final meta = [
+      if (item.published != null) timeAgo(item.published),
+      if (item.author.trim().isNotEmpty) item.author.trim(),
+    ].join(' · ');
+
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: overlayStyle,
+      child: Scaffold(
+        body: CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            SliverAppBar(
+              backgroundColor: Colors.white,
+              elevation: 0,
+              pinned: true,
+              expandedHeight: _expandedHeight,
+              leading: IconButton(
+                icon: Icon(Icons.arrow_back, color: iconColor),
+                onPressed: () => Navigator.of(context).pop(),
+                tooltip: 'Назад',
+              ),
+              actions: [
+                IconButton(
+                  icon: Icon(Icons.share, color: iconColor),
+                  onPressed: _share,
+                  tooltip: 'Поделиться',
+                ),
+              ],
+              systemOverlayStyle: overlayStyle,
+              flexibleSpace: FlexibleSpaceBar(
+                background: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    if (item.image.isEmpty)
+                      Container(color: Colors.grey.shade200)
+                    else
+                      Image.network(
+                        item.image,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) =>
+                            Container(color: Colors.grey.shade200),
+                      ),
+                    Positioned.fill(
+                      child: IgnorePointer(
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.topCenter,
+                              end: Alignment.bottomCenter,
+                              colors: [
+                                Colors.transparent,
+                                Colors.black.withOpacity(0.1),
+                                Colors.black.withOpacity(0.3),
+                                Colors.black.withOpacity(0.5),
+                              ],
+                              stops: const [0.5, 0.75, 0.9, 1.0],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      left: 12,
+                      right: 12,
+                      bottom: 12,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (item.rubric != null &&
+                              item.rubric!.name.isNotEmpty)
+                            Text(
+                              item.rubric!.name.toUpperCase(),
+                              style: const TextStyle(
+                                color: Colors.white70,
+                                fontSize: 12,
+                                fontWeight: FontWeight.w500,
+                                shadows: [
+                                  Shadow(
+                                    color: Colors.black54,
+                                    blurRadius: 4,
+                                    offset: Offset(0, 1),
+                                  )
+                                ],
+                              ),
+                            ),
+                          Text(
+                            item.title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 22,
+                              fontWeight: FontWeight.w600,
+                              height: 1.2,
+                              shadows: [
+                                Shadow(
+                                  color: Colors.black54,
+                                  blurRadius: 4,
+                                  offset: Offset(0, 1),
+                                )
+                              ],
+                            ),
+                          ),
+                          if (descPlain.isNotEmpty) ...[
+                            const SizedBox(height: 8),
+                            Text(
+                              descPlain,
+                              maxLines: 3,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 16,
+                                height: 1.25,
+                                shadows: [
+                                  Shadow(
+                                    color: Colors.black54,
+                                    blurRadius: 4,
+                                    offset: Offset(0, 1),
+                                  )
+                                ],
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (meta.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 12),
+                        child: Text(
+                          meta,
+                          style: const TextStyle(
+                            fontSize: 14,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ),
+                    Html(data: item.contentFull),
+                  ],
+                ),
+              ),
+            ),
+            const SliverPadding(padding: EdgeInsets.only(bottom: 24)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/news/news_detail_screen.dart
+++ b/lib/features/news/news_detail_screen.dart
@@ -1,237 +1,121 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_html/flutter_html.dart';
-import 'package:share_plus/share_plus.dart';
 
-import '../../core/utils/image_brightness.dart';
-import '../../core/utils/time_ago.dart';
+import '../../core/services/news_api_service.dart';
 import 'models/news_item.dart';
+import 'news_article_view.dart';
 
 class NewsDetailScreen extends StatefulWidget {
-  final NewsItem item;
-  const NewsDetailScreen({super.key, required this.item});
+  const NewsDetailScreen({
+    super.key,
+    required this.initialItems,
+    required this.initialIndex,
+  });
+
+  final List<NewsItem> initialItems;
+  final int initialIndex;
 
   @override
   State<NewsDetailScreen> createState() => _NewsDetailScreenState();
 }
 
 class _NewsDetailScreenState extends State<NewsDetailScreen> {
-  final _scrollController = ScrollController();
-  bool _collapsed = false;
-  bool? _isPhotoDark;
-
-  static const double _expandedHeight = 320;
+  final _api = NewsApiService();
+  late List<NewsItem> _items;
+  late int _currentIndex;
+  bool _isLoading = false;
+  String? _error;
+  int _page = 1;
+  int _pages = 1;
+  late PageController _pageController;
 
   @override
   void initState() {
     super.initState();
-    _scrollController.addListener(_onScroll);
-    _analyzePhoto();
+    _items = List.of(widget.initialItems);
+    _currentIndex = widget.initialIndex;
+    _pageController = PageController(initialPage: _currentIndex);
+    _page = (_items.length / 20).ceil() + 1;
+    _pages = _page;
   }
 
   @override
   void dispose() {
-    _scrollController.removeListener(_onScroll);
-    _scrollController.dispose();
+    _pageController.dispose();
     super.dispose();
   }
 
-  void _onScroll() {
-    if (!mounted) return;
-    final topPad = MediaQuery.of(context).padding.top;
-    final threshold = _expandedHeight - (kToolbarHeight + topPad);
-    final nowCollapsed =
-        _scrollController.positions.isNotEmpty &&
-        _scrollController.offset >= threshold;
-    if (nowCollapsed != _collapsed) {
-      setState(() => _collapsed = nowCollapsed);
+  void _onPageChanged(int index) {
+    setState(() => _currentIndex = index);
+    if (index >= _items.length - 2) {
+      _loadMore();
     }
   }
 
-  Future<void> _analyzePhoto() async {
-    final url = widget.item.image;
-    if (url.isEmpty) return;
-    final dark = await isImageDark(url);
-    if (mounted) setState(() => _isPhotoDark = dark);
-  }
-
-  void _share() {
-    final link = widget.item.url;
-    final title = widget.item.title;
-    final text = [title, link].where((e) => e.trim().isNotEmpty).join('\n');
-    if (text.isNotEmpty) Share.share(text);
+  Future<void> _loadMore() async {
+    if (_isLoading || _page > _pages) return;
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final page = await _api.fetchNews(page: _page);
+      setState(() {
+        _items.addAll(page.items);
+        _page = page.page + 1;
+        _pages = page.pages;
+      });
+    } catch (e) {
+      if (e.toString().contains('No news items')) {
+        _pages = _page - 1;
+      } else {
+        if (mounted) setState(() => _error = 'Ошибка загрузки');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      } else {
+        _isLoading = false;
+      }
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    final item = widget.item;
-    final dark = _isPhotoDark ?? true;
-    final iconColor =
-        _collapsed ? Colors.black87 : (dark ? Colors.white : Colors.black87);
-    final overlayStyle = _collapsed
-        ? SystemUiOverlayStyle.dark
-        : (dark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark);
-
-    final descPlain = item.contentPreview
-        .replaceAll(RegExp(r'<[^>]*>'), ' ')
-        .replaceAll(RegExp(r'\s+'), ' ')
-        .trim();
-
-    final meta = [
-      if (item.published != null) timeAgo(item.published),
-      if (item.author.trim().isNotEmpty) item.author.trim(),
-    ].join(' · ');
-
-    return AnnotatedRegion<SystemUiOverlayStyle>(
-      value: overlayStyle,
-      child: Scaffold(
-        body: CustomScrollView(
-          controller: _scrollController,
-          slivers: [
-            SliverAppBar(
-              backgroundColor: Colors.white,
-              elevation: 0,
-              pinned: true,
-              expandedHeight: _expandedHeight,
-              leading: IconButton(
-                icon: Icon(Icons.arrow_back, color: iconColor),
-                onPressed: () => Navigator.of(context).pop(),
-                tooltip: 'Назад',
-              ),
-              actions: [
-                IconButton(
-                  icon: Icon(Icons.share, color: iconColor),
-                  onPressed: _share,
-                  tooltip: 'Поделиться',
-                ),
-              ],
-              systemOverlayStyle: overlayStyle,
-              flexibleSpace: FlexibleSpaceBar(
-                background: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    if (item.image.isEmpty)
-                      Container(color: Colors.grey.shade200)
-                    else
-                      Image.network(
-                        item.image,
-                        fit: BoxFit.cover,
-                        errorBuilder: (_, __, ___) =>
-                            Container(color: Colors.grey.shade200),
-                      ),
-                    Positioned.fill(
-                      child: IgnorePointer(
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [
-                                Colors.transparent,
-                                Colors.black.withOpacity(0.1),
-                                Colors.black.withOpacity(0.3),
-                                Colors.black.withOpacity(0.5),
-                              ],
-                              stops: const [0.5, 0.75, 0.9, 1.0],
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    Positioned(
-                      left: 12,
-                      right: 12,
-                      bottom: 12,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          if (item.rubric != null &&
-                              item.rubric!.name.isNotEmpty)
-                            Text(
-                              item.rubric!.name.toUpperCase(),
-                              style: const TextStyle(
-                                color: Colors.white70,
-                                fontSize: 12,
-                                fontWeight: FontWeight.w500,
-                                shadows: [
-                                  Shadow(
-                                    color: Colors.black54,
-                                    blurRadius: 4,
-                                    offset: Offset(0, 1),
-                                  )
-                                ],
-                              ),
-                            ),
-                          Text(
-                            item.title,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 22,
-                              fontWeight: FontWeight.w600,
-                              height: 1.2,
-                              shadows: [
-                                Shadow(
-                                  color: Colors.black54,
-                                  blurRadius: 4,
-                                  offset: Offset(0, 1),
-                                )
-                              ],
-                            ),
-                          ),
-                          if (descPlain.isNotEmpty) ...[
-                            const SizedBox(height: 8),
-                            Text(
-                              descPlain,
-                              maxLines: 3,
-                              overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 16,
-                                height: 1.25,
-                                shadows: [
-                                  Shadow(
-                                    color: Colors.black54,
-                                    blurRadius: 4,
-                                    offset: Offset(0, 1),
-                                  )
-                                ],
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
+    return Scaffold(
+      body: Stack(
+        children: [
+          PageView.builder(
+            controller: _pageController,
+            itemCount: _items.length,
+            onPageChanged: _onPageChanged,
+            itemBuilder: (context, index) =>
+                NewsArticleView(item: _items[index]),
+          ),
+          if (_isLoading)
+            const Positioned(
+              bottom: 16,
+              left: 0,
+              right: 0,
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          if (_error != null)
+            Positioned(
+              bottom: 16,
+              left: 0,
+              right: 0,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(_error!),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: _loadMore,
+                    child: const Text('Повторить'),
+                  ),
+                ],
               ),
             ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (meta.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: 12),
-                        child: Text(
-                          meta,
-                          style: const TextStyle(
-                            fontSize: 14,
-                            color: Colors.grey,
-                          ),
-                        ),
-                      ),
-                    Html(data: item.contentFull),
-                  ],
-                ),
-              ),
-            ),
-            const SliverPadding(padding: EdgeInsets.only(bottom: 24)),
-          ],
-        ),
+        ],
       ),
     );
   }

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -147,7 +147,10 @@ class _NewsListState extends State<NewsList> {
             onTap: () {
               Navigator.of(context).push(
                 MaterialPageRoute(
-                  builder: (_) => NewsDetailScreen(item: item),
+                  builder: (_) => NewsDetailScreen(
+                    initialItems: _items,
+                    initialIndex: index,
+                  ),
                 ),
               );
             },

--- a/test/features/news/news_detail_screen_test.dart
+++ b/test/features/news/news_detail_screen_test.dart
@@ -17,7 +17,14 @@ void main() {
       rubric: null,
     );
 
-    await tester.pumpWidget(MaterialApp(home: NewsDetailScreen(item: item)));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NewsDetailScreen(
+          initialItems: [item],
+          initialIndex: 0,
+        ),
+      ),
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('Test title'), findsOneWidget);


### PR DESCRIPTION
## Summary
- Convert `NewsDetailScreen` into a paginated view that accepts an initial list and index and loads more articles on demand
- Extract article rendering into reusable `NewsArticleView`
- Pass full item list and index from `NewsList` to start pager at tapped article

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ffce73b0832687529e6bfd1a1f64