### PR TITLE
Add shimmer loading skeleton for NewsList

### DIFF
--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -4,6 +4,7 @@ import '../../core/utils/time_ago.dart';
 import 'models/news_item.dart';
 import 'package:share_plus/share_plus.dart';
 import 'news_detail_screen.dart';
+import 'widgets/news_list_item_skeleton.dart';
 
 class NewsList extends StatefulWidget {
   const NewsList({super.key, this.categoryId});
@@ -85,7 +86,11 @@ class _NewsListState extends State<NewsList> {
   Widget build(BuildContext context) {
     if (_items.isEmpty) {
       if (_isLoading) {
-        return const Center(child: CircularProgressIndicator());
+        return ListView.separated(
+          itemCount: 5,
+          separatorBuilder: (_, __) => const Divider(height: 0),
+          itemBuilder: (_, __) => const NewsListItemSkeleton(),
+        );
       }
       if (_error != null) {
         return Center(
@@ -120,10 +125,7 @@ class _NewsListState extends State<NewsList> {
         itemBuilder: (context, index) {
           if (index >= _items.length) {
             if (_isLoading) {
-              return const Padding(
-                padding: EdgeInsets.symmetric(vertical: 16),
-                child: Center(child: CircularProgressIndicator()),
-              );
+              return const NewsListItemSkeleton();
             } else {
               return Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16),

--- a/lib/features/news/widgets/news_list_item_skeleton.dart
+++ b/lib/features/news/widgets/news_list_item_skeleton.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class NewsListItemSkeleton extends StatelessWidget {
+  const NewsListItemSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final imageHeight = MediaQuery.of(context).size.width * 0.6;
+    return Shimmer.fromColors(
+      baseColor: Colors.grey.shade300,
+      highlightColor: Colors.grey.shade100,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: double.infinity,
+            height: imageHeight,
+            color: Colors.grey,
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 80,
+                  height: 12,
+                  color: Colors.grey,
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  width: double.infinity,
+                  height: 18,
+                  color: Colors.grey,
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  width: double.infinity,
+                  height: 14,
+                  color: Colors.grey,
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Container(
+                        height: 14,
+                        color: Colors.grey,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Container(
+                      width: 24,
+                      height: 24,
+                      color: Colors.grey,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -717,6 +717,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   flutter_svg: ^2.0.10+1
   barcode_widget: ^2.0.4
   palette_generator: ^0.3.3+7
+  shimmer: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `shimmer` package
- create `NewsListItemSkeleton` widget to show placeholders
- use skeleton items during initial and bottom list loading

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c601f2dd108326975cbc115e9dcd64