### PR TITLE
feat: cache network images

### DIFF
--- a/lib/features/news/news_article_view.dart
+++ b/lib/features/news/news_article_view.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_html/flutter_html.dart';
@@ -114,10 +115,13 @@ class _NewsArticleViewState extends State<NewsArticleView> {
                     if (item.image.isEmpty)
                       Container(color: Colors.grey.shade200)
                     else
-                      Image.network(
-                        item.image,
+                      CachedNetworkImage(
+                        imageUrl: item.image,
                         fit: BoxFit.cover,
-                        errorBuilder: (_, __, ___) =>
+                        fadeInDuration: const Duration(milliseconds: 300),
+                        placeholder: (_, __) =>
+                            Container(color: Colors.grey.shade200),
+                        errorWidget: (_, __, ___) =>
                             Container(color: Colors.grey.shade200),
                       ),
                     Positioned.fill(

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+
 import '../../core/services/news_api_service.dart';
 import '../../core/utils/time_ago.dart';
 import 'models/news_item.dart';
-import 'package:share_plus/share_plus.dart';
 import 'news_detail_screen.dart';
 import 'widgets/news_list_item_skeleton.dart';
 
@@ -178,12 +180,19 @@ class NewsListItem extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (item.image.isNotEmpty)
-            Image.network(
-              item.image,
+            CachedNetworkImage(
+              imageUrl: item.image,
               width: double.infinity,
               height: imageHeight,
               fit: BoxFit.cover,
-              errorBuilder: (_, __, ___) => Container(
+              fadeInDuration: const Duration(milliseconds: 300),
+              placeholder: (_, __) => Container(
+                width: double.infinity,
+                height: imageHeight,
+                color: Colors.grey.shade200,
+              ),
+              errorWidget: (_, __, ___) => Container(
+                width: double.infinity,
                 height: imageHeight,
                 color: Colors.grey.shade200,
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   barcode_widget: ^2.0.4
   palette_generator: ^0.3.3+7
   shimmer: ^3.0.0
+  cached_network_image: ^3.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `cached_network_image` dependency
- use `CachedNetworkImage` with placeholders for news article images

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: package not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60356c6a48326b1019cd1217f1cf7