### PR TITLE
Add hero transitions for news images

### DIFF
--- a/lib/features/news/news_article_view.dart
+++ b/lib/features/news/news_article_view.dart
@@ -114,11 +114,14 @@ class _NewsArticleViewState extends State<NewsArticleView> {
                     if (item.image.isEmpty)
                       Container(color: Colors.grey.shade200)
                     else
-                      Image.network(
-                        item.image,
-                        fit: BoxFit.cover,
-                        errorBuilder: (_, __, ___) =>
-                            Container(color: Colors.grey.shade200),
+                      Hero(
+                        tag: item.id,
+                        child: Image.network(
+                          item.image,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) =>
+                              Container(color: Colors.grey.shade200),
+                        ),
                       ),
                     Positioned.fill(
                       child: IgnorePointer(

--- a/lib/features/news/news_detail_screen.dart
+++ b/lib/features/news/news_detail_screen.dart
@@ -88,8 +88,11 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
             controller: _pageController,
             itemCount: _items.length,
             onPageChanged: _onPageChanged,
-            itemBuilder: (context, index) =>
-                NewsArticleView(item: _items[index]),
+            pageSnapping: true,
+            itemBuilder: (context, index) => NewsArticleView(
+              key: ValueKey(_items[index].id),
+              item: _items[index],
+            ),
           ),
           if (_isLoading)
             const Positioned(

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -178,14 +178,17 @@ class NewsListItem extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (item.image.isNotEmpty)
-            Image.network(
-              item.image,
-              width: double.infinity,
-              height: imageHeight,
-              fit: BoxFit.cover,
-              errorBuilder: (_, __, ___) => Container(
+            Hero(
+              tag: item.id,
+              child: Image.network(
+                item.image,
+                width: double.infinity,
                 height: imageHeight,
-                color: Colors.grey.shade200,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => Container(
+                  height: imageHeight,
+                  color: Colors.grey.shade200,
+                ),
               ),
             )
           else


### PR DESCRIPTION
## Summary
- Animate news list image into detail view using Hero with unique tag
- Use Hero for top article image and ensure PageView pages keyed by item id
- Enable page snapping for article PageView

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6052bcf288326b9f43302c9b7b218