### PR TITLE
Adjust font sizes for news screens

### DIFF
--- a/lib/features/news/news_article_view.dart
+++ b/lib/features/news/news_article_view.dart
@@ -183,7 +183,7 @@ class _NewsArticleViewState extends State<NewsArticleView> {
                               item.rubric!.name.toUpperCase(),
                               style: const TextStyle(
                                 color: Colors.white70,
-                                fontSize: 12,
+                                fontSize: 14,
                                 fontWeight: FontWeight.w500,
                                 shadows: [
                                   Shadow(
@@ -200,7 +200,7 @@ class _NewsArticleViewState extends State<NewsArticleView> {
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(
                               color: Colors.white,
-                              fontSize: 22,
+                              fontSize: 24,
                               fontWeight: FontWeight.w600,
                               height: 1.2,
                               shadows: [
@@ -220,7 +220,7 @@ class _NewsArticleViewState extends State<NewsArticleView> {
                               overflow: TextOverflow.ellipsis,
                               style: const TextStyle(
                                 color: Colors.white,
-                                fontSize: 16,
+                                fontSize: 18,
                                 height: 1.25,
                                 shadows: [
                                   Shadow(
@@ -251,7 +251,7 @@ class _NewsArticleViewState extends State<NewsArticleView> {
                         child: Text(
                           meta,
                           style: const TextStyle(
-                            fontSize: 14,
+                            fontSize: 16,
                             color: Colors.grey,
                           ),
                         ),
@@ -259,7 +259,7 @@ class _NewsArticleViewState extends State<NewsArticleView> {
                     Html(
                       data: item.contentFull,
                       style: {
-                        '*': Style(fontSize: FontSize(16 * _textScaleFactor)),
+                        '*': Style(fontSize: FontSize(18 * _textScaleFactor)),
                       },
                     ),
                   ],

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -206,7 +206,7 @@ class NewsListItem extends StatelessWidget {
                   Text(
                     item.rubric!.name.toUpperCase(),
                     style: const TextStyle(
-                      fontSize: 12,
+                      fontSize: 14,
                       fontWeight: FontWeight.w500,
                       color: Colors.grey,
                     ),
@@ -214,7 +214,7 @@ class NewsListItem extends StatelessWidget {
                 Text(
                   item.title,
                   style: const TextStyle(
-                    fontSize: 18,
+                    fontSize: 20,
                     fontWeight: FontWeight.w400,
                     fontFamily: 'Roboto',
                   ),
@@ -224,7 +224,7 @@ class NewsListItem extends StatelessWidget {
                   child: Text(
                     item.contentPreview,
                     style: const TextStyle(
-                      fontSize: 14,
+                      fontSize: 16,
                       fontWeight: FontWeight.w300,
                       fontFamily: 'Roboto',
                     ),
@@ -242,7 +242,7 @@ class NewsListItem extends StatelessWidget {
                             if (item.author.trim().isNotEmpty) item.author,
                           ].join(' · '),
                           style: const TextStyle(
-                            fontSize: 14,
+                            fontSize: 16,
                             color: Colors.grey,
                           ),
                         ),


### PR DESCRIPTION
## Summary
- bump typography in news list items for better readability
- enlarge text styles in news article view, including HTML content

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60951c24c8326a7d62ccbedcfc287