### PR TITLE
Fix TabBar alignment to remove leading gap

### DIFF
--- a/lib/features/auth/profile_screen.dart
+++ b/lib/features/auth/profile_screen.dart
@@ -438,10 +438,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
           bottom: const TabBar(
             labelColor: Color(0xFF182857),
             unselectedLabelColor: Colors.black54,
-              tabs: [
-                Tab(text: 'Клубная карта'),
-                Tab(text: 'Профиль'),
-              ],
+            tabAlignment: TabAlignment.start,
+            tabs: [
+              Tab(text: 'Клубная карта'),
+              Tab(text: 'Профиль'),
+            ],
           ),
         ),
         body: TabBarView(

--- a/lib/features/mclub/mclub_screen.dart
+++ b/lib/features/mclub/mclub_screen.dart
@@ -429,6 +429,7 @@ class _MClubScreenState extends State<MClubScreen>
                           key: _tabBarKey,
                           controller: _tabController,
                           isScrollable: true,
+                          tabAlignment: TabAlignment.start,
                           labelColor: const Color(0xFF182857),
                           unselectedLabelColor: Colors.black54,
                           indicatorColor: Colors.transparent,

--- a/lib/features/news/news_category_screen.dart
+++ b/lib/features/news/news_category_screen.dart
@@ -18,6 +18,7 @@ class NewsCategoryScreen extends StatelessWidget {
           title: Text(category.name),
           bottom: TabBar(
             isScrollable: true,
+            tabAlignment: TabAlignment.start,
             tabs: [
               const Tab(text: 'Все'),
               for (final rubric in category.rubrics) Tab(text: rubric.name),

--- a/lib/features/news/news_screen.dart
+++ b/lib/features/news/news_screen.dart
@@ -65,6 +65,7 @@ class _NewsScreenState extends State<NewsScreen> {
         children: [
           TabBar(
             isScrollable: true,
+            tabAlignment: TabAlignment.start,
             tabs: [
               const Tab(text: 'Все новости'),
               for (final cat in _categories) Tab(text: cat.name),

--- a/lib/features/uae_unlocked/uae_unlocked_screen.dart
+++ b/lib/features/uae_unlocked/uae_unlocked_screen.dart
@@ -384,6 +384,7 @@ class _UAEUnlockedScreenState extends State<UAEUnlockedScreen>
                           key: _tabBarKey,
                           controller: _tabController,
                           isScrollable: true,
+                          tabAlignment: TabAlignment.start,
                           labelColor: const Color(0xFF182857),
                           unselectedLabelColor: Colors.black54,
                           indicatorColor: Colors.transparent,


### PR DESCRIPTION
## Summary
- ensure TabBar tabs align to the start so the first tab touches the left edge on all screens

## Testing
- `dart format lib/features/news/news_screen.dart lib/features/news/news_category_screen.dart lib/features/uae_unlocked/uae_unlocked_screen.dart lib/features/mclub/mclub_screen.dart lib/features/auth/profile_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60f802b1c832685895f5bb09677ca