### PR TITLE
feat: rename recommendations section

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -68,7 +68,7 @@ class _HomeScreenState extends State<HomeScreen> {
         onTap: (i) => setState(() => _index = i),
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.local_offer), label: 'М-Клуб'),
-          BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Рекомендации'),
+          BottomNavigationBarItem(icon: Icon(Icons.travel_explore), label: 'Открой ОАЭ!'),
           BottomNavigationBarItem(icon: Icon(Icons.radio), label: 'Радио'),
           BottomNavigationBarItem(icon: Icon(Icons.article), label: 'Новости'),
         ],


### PR DESCRIPTION
## Summary
- use travel_explore icon for recommendations nav item
- rename recommendations section to "Открой ОАЭ!"

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib/features/home/home_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6138830cc83269e6cb449c08905f5