### PR TITLE
Handle storage errors during auth check

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -247,8 +247,13 @@ class ApiService {
 
   /// Проверка, есть ли сохранённый токен
   Future<bool> isLoggedIn() async {
-    final token = await _storage.read(key: 'auth_token');
-    return token != null;
+    try {
+      final token = await _storage.read(key: 'auth_token');
+      return token != null;
+    } catch (e) {
+      debugPrint('isLoggedIn error: $e');
+      return false;
+    }
   }
   String _resolveLang() {
     final code = ui.PlatformDispatcher.instance.locale.languageCode.toLowerCase();

--- a/lib/core/widgets/auth_gate.dart
+++ b/lib/core/widgets/auth_gate.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../../features/auth/auth_email_screen.dart';
 import '../services/api_service.dart' show ApiService;
@@ -28,12 +29,21 @@ class _AuthGateState extends State<AuthGate> {
   }
 
   Future<void> _check() async {
-    final ok = await ApiService().isLoggedIn();
-    if (!mounted) return;
-    setState(() {
-      _loggedIn = ok;
-      _loading = false;
-    });
+    try {
+      final ok = await ApiService().isLoggedIn();
+      if (!mounted) return;
+      setState(() {
+        _loggedIn = ok;
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('AuthGate._check error: $e');
+      if (!mounted) return;
+      setState(() {
+        _loggedIn = false;
+        _loading = false;
+      });
+    }
   }
 
   /// Выполняет повторную проверку токена и обновляет состояние виджета.


### PR DESCRIPTION
## Summary
- Catch errors from ApiService.isLoggedIn in AuthGate and ensure loading spinner hides
- Wrap storage read in ApiService.isLoggedIn with try/catch and log failures

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c62ccb02a88326b9f5d24d0e44a94a