### PR TITLE
Guard release keystore config in Gradle

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -42,17 +42,27 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["storePassword"] as String
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
+        val storeFileProp = keystoreProperties.getProperty("storeFile")
+        val storePasswordProp = keystoreProperties.getProperty("storePassword")
+        val keyAliasProp = keystoreProperties.getProperty("keyAlias")
+        val keyPasswordProp = keystoreProperties.getProperty("keyPassword")
+
+        if (storeFileProp != null && storePasswordProp != null &&
+            keyAliasProp != null && keyPasswordProp != null) {
+            create("release") {
+                storeFile = file(storeFileProp)
+                storePassword = storePasswordProp
+                keyAlias = keyAliasProp
+                keyPassword = keyPasswordProp
+            }
+        } else {
+            println("Warning: key.properties is missing required fields; using debug signing config.")
         }
     }
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
+            signingConfig = signingConfigs.findByName("release") ?: signingConfigs.getByName("debug")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Guard release signingConfig with null checks for key properties
- Fall back to debug signing when key.properties is incomplete

## Testing
- `gradle -p android tasks` *(fails: /workspace/M-Club-App-V4/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68c6a7770df08326b2d390ed7c317720