### PR TITLE
feat: add radio controls and track info

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -29,6 +29,20 @@ class RadioController extends ChangeNotifier {
   PlayerState get playerState => _playerState;
   RadioTrack? get track => _track;
 
+  /// Starts playback if the stream is not playing and stops otherwise.
+  Future<void> togglePlay() async {
+    if (_player.playing) {
+      await _player.stop();
+    } else {
+      // If no source is loaded yet, start the stream with the current quality.
+      if (_player.audioSource == null && _streams.isNotEmpty) {
+        await _startStream();
+      } else {
+        _player.play();
+      }
+    }
+  }
+
   /// Loads available streams and starts playback using selected [quality].
   Future<void> init({String? quality}) async {
     _streams = await _api.fetchStreams();

--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -1,9 +1,79 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:m_club/features/radio/radio_controller.dart';
 
 class RadioScreen extends StatelessWidget {
   const RadioScreen({super.key});
+
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text('Русские Эмираты: онлайн-радио'));
+    return ChangeNotifierProvider(
+      create: (_) => RadioController()..init(),
+      child: const _RadioView(),
+    );
   }
 }
+
+class _RadioView extends StatelessWidget {
+  const _RadioView();
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<RadioController>();
+    final track = controller.track;
+
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Image.asset(
+            'assets/images/Radio_RE_Logo.webp',
+            width: 150,
+          ),
+          const SizedBox(height: 16),
+          if (track != null) ...[
+            if (track.image.isNotEmpty)
+              Image.network(
+                track.image,
+                height: 200,
+                width: 200,
+                fit: BoxFit.cover,
+              ),
+            const SizedBox(height: 8),
+            Text('${track.artist} – ${track.title}',
+                textAlign: TextAlign.center),
+            const SizedBox(height: 16),
+          ],
+          if (controller.streams.isNotEmpty)
+            DropdownButton<String>(
+              value: controller.quality,
+              items: controller.streams.keys
+                  .map(
+                    (q) => DropdownMenuItem(
+                      value: q,
+                      child: Text('$q kbps'),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (q) {
+                if (q != null) {
+                  context.read<RadioController>().setQuality(q);
+                }
+              },
+            ),
+          const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: () => context.read<RadioController>().togglePlay(),
+            icon: Icon(controller.playerState.playing
+                ? Icons.stop
+                : Icons.play_arrow),
+            label: Text(
+                controller.playerState.playing ? 'Stop' : 'Play'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- extend radio controller with playback toggle
- add radio screen with provider, track info, quality selector, and play/stop button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fe1b65888326b1239b33459d1481