### PR TITLE
feat(radio): update track info via handler

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -83,14 +83,7 @@ class RadioController extends ChangeNotifier {
     try {
       final info = await _api.fetchTrackInfo();
       _track = info;
-      _audioHandler.mediaItem.add(
-        MediaItem(
-          id: 'mclub_radio',
-          title: info.title,
-          artist: info.artist,
-          artUri: Uri.parse('asset:///assets/images/Radio_RE_Logo.webp'),
-        ),
-      );
+      (_audioHandler as _RadioAudioHandler).updateTrack(info);
       notifyListeners();
     } catch (_) {
       // ignore errors
@@ -123,6 +116,18 @@ class _RadioAudioHandler extends BaseAudioHandler with SeekHandler {
   }
 
   final AudioPlayer _player;
+
+  /// Updates the current track information for external clients.
+  void updateTrack(RadioTrack track) {
+    mediaItem.add(
+      MediaItem(
+        id: 'mclub_radio',
+        title: track.title,
+        artist: track.artist,
+        artUri: Uri.parse('asset:///assets/images/Radio_RE_Logo.webp'),
+      ),
+    );
+  }
 
   PlaybackState _transformEvent(PlaybackEvent event) {
     return PlaybackState(


### PR DESCRIPTION
## Summary
- add method in _RadioAudioHandler to update track metadata
- reuse new handler method in _updateTrackInfo

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7084ad1e88326b82cebb9f9068ab6