### PR TITLE
Handle null track info in radio controller

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -82,6 +82,7 @@ class RadioController extends ChangeNotifier {
   Future<void> _updateTrackInfo() async {
     try {
       final info = await _api.fetchTrackInfo();
+      if (info == null) return;
       _track = info;
       (_audioHandler as _RadioAudioHandler).updateTrack(info);
       notifyListeners();


### PR DESCRIPTION
## Summary
- Guard against null track info before updating player state

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7096bf6d483269752d573860ced21