### PR TITLE
Handle radio playback errors with manual restart

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -15,6 +15,14 @@ class RadioController extends ChangeNotifier {
       _playerState = state;
       notifyListeners();
     });
+
+    _player.processingStateStream.listen((state) {
+      if (state == ProcessingState.idle && _player.audioSource != null) {
+        _hasError = true;
+        _audioHandler.stop();
+      }
+      notifyListeners();
+    });
   }
 
   final RadioApiService _api = RadioApiService();
@@ -26,11 +34,13 @@ class RadioController extends ChangeNotifier {
   PlayerState _playerState = PlayerState(false, ProcessingState.idle);
   RadioTrack? _track;
   Timer? _trackTimer;
+  bool _hasError = false;
 
   Map<String, String> get streams => _streams;
   String? get quality => _quality;
   PlayerState get playerState => _playerState;
   RadioTrack? get track => _track;
+  bool get hasError => _hasError;
 
   /// Starts playback if the stream is not playing and stops otherwise.
   Future<void> togglePlay() async {
@@ -43,6 +53,7 @@ class RadioController extends ChangeNotifier {
         await _audioHandler.play();
       }
     }
+    _hasError = false;
   }
 
   /// Loads available streams and starts playback using selected [quality].
@@ -66,6 +77,7 @@ class RadioController extends ChangeNotifier {
   Future<void> _startStream() async {
     final url = _streams[_quality];
     if (url == null) return;
+    _hasError = false;
     await _audioHandler.stop();
     await _player.setUrl(url);
     await _audioHandler.play();

--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -63,6 +63,13 @@ class _RadioView extends StatelessWidget {
               },
             ),
           const SizedBox(height: 16),
+          if (controller.hasError) ...[
+            const Text(
+              'Playback error. Press Play to try again.',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+          ],
           ElevatedButton.icon(
             onPressed: () => context.read<RadioController>().togglePlay(),
             icon: Icon(controller.playerState.playing


### PR DESCRIPTION
## Summary
- detect idle processing state and mark radio playback errors
- expose error state and show retry prompt on radio screen

## Testing
- ⚠️ `dart format lib/features/radio/radio_controller.dart lib/features/radio/radio_screen.dart` (command not found)
- ⚠️ `flutter analyze` (command not found)
- ⚠️ `flutter test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c70ce3efe083269bfc721cbcef51f5