### PR TITLE
Handle radio stream loading errors

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -67,7 +67,14 @@ class RadioController extends ChangeNotifier {
       _audioHandlerCompleter.complete();
     }
 
-    _streams = await _api.fetchStreams();
+    try {
+      _streams = await _api.fetchStreams();
+    } catch (e, s) {
+      _hasError = true;
+      notifyListeners();
+      debugPrint('Failed to fetch radio streams: $e\n$s');
+      return;
+    }
     if (_streams.isEmpty) return;
 
     _quality = quality ?? _streams.keys.first;
@@ -89,7 +96,14 @@ class RadioController extends ChangeNotifier {
     if (url == null) return;
     _hasError = false;
     await _audioHandler.stop();
-    await _player.setUrl(url);
+    try {
+      await _player.setUrl(url);
+    } catch (e, s) {
+      _hasError = true;
+      notifyListeners();
+      debugPrint('Failed to set radio stream URL: $e\n$s');
+      return;
+    }
     await _audioHandler.play();
     await _updateTrackInfo();
   }


### PR DESCRIPTION
## Summary
- guard `fetchStreams` and player `setUrl` with try/catch
- flag errors, notify listeners, and log diagnostics when radio setup fails

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c711d798508326bcc268c8192c57ce