### PR TITLE
Add volume controls to radio player

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -38,12 +38,15 @@ class RadioController extends ChangeNotifier {
   RadioTrack? _track;
   Timer? _trackTimer;
   bool _hasError = false;
+  double _volume = 1.0;
+  double _previousVolume = 1.0;
 
   Map<String, String> get streams => _streams;
   String? get quality => _quality;
   PlayerState get playerState => _playerState;
   RadioTrack? get track => _track;
   bool get hasError => _hasError;
+  double get volume => _volume;
 
   /// Starts playback if the stream is not playing and stops otherwise.
   Future<void> togglePlay() async {
@@ -58,6 +61,28 @@ class RadioController extends ChangeNotifier {
       }
     }
     _hasError = false;
+  }
+
+  /// Sets the player volume to a value between 0.0 and 1.0.
+  Future<void> setVolume(double value) async {
+    _volume = value.clamp(0.0, 1.0);
+    if (_volume > 0) {
+      _previousVolume = _volume;
+    }
+    await _player.setVolume(_volume);
+    notifyListeners();
+  }
+
+  /// Toggles mute state preserving the last non-zero volume value.
+  Future<void> toggleMute() async {
+    if (_volume > 0) {
+      _previousVolume = _volume;
+      _volume = 0;
+    } else {
+      _volume = _previousVolume;
+    }
+    await _player.setVolume(_volume);
+    notifyListeners();
   }
 
   /// Loads available streams and starts playback using selected [quality].

--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -129,13 +129,56 @@ class _RadioView extends StatelessWidget {
                   ),
                   const SizedBox(width: 16),
                   IconButton(
-                    onPressed: () {},
-                    icon: const Icon(Icons.volume_up),
+                    onPressed: () => _showVolumeDialog(context),
+                    icon: Icon(
+                      controller.volume == 0
+                          ? Icons.volume_off
+                          : Icons.volume_up,
+                    ),
                   ),
                 ],
               ),
             ),
           ],
+        );
+      },
+    );
+  }
+
+  void _showVolumeDialog(BuildContext context) {
+    final controller = context.read<RadioController>();
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Volume'),
+          content: StatefulBuilder(
+            builder: (context, setState) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Slider(
+                    value: controller.volume,
+                    onChanged: (value) {
+                      controller.setVolume(value);
+                      setState(() {});
+                    },
+                  ),
+                  IconButton(
+                    icon: Icon(
+                      controller.volume == 0
+                          ? Icons.volume_off
+                          : Icons.volume_up,
+                    ),
+                    onPressed: () {
+                      controller.toggleMute();
+                      setState(() {});
+                    },
+                  ),
+                ],
+              );
+            },
+          ),
         );
       },
     );


### PR DESCRIPTION
## Summary
- track volume state in `RadioController` with setter and mute toggle
- expose volume and connect slider/mute dialog to volume icon in `RadioScreen`

## Testing
- ⚠️ `dart format lib/features/radio/radio_controller.dart lib/features/radio/radio_screen.dart` (command not found: dart)
- ⚠️ `flutter test` (command not found: flutter)


------
https://chatgpt.com/codex/tasks/task_e_68c723b224c083268f941facac06d41a