### PR TITLE
feat(radio): separate track text

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -74,13 +74,14 @@ class _RadioView extends StatelessWidget {
                     track.artist,
                     style: Theme.of(context)
                         .textTheme
-                        .titleMedium
+                        .headlineSmall
                         ?.copyWith(fontWeight: FontWeight.bold),
                     textAlign: TextAlign.center,
                   ),
+                  const SizedBox(height: 4),
                   Text(
                     track.title,
-                    style: Theme.of(context).textTheme.titleMedium,
+                    style: Theme.of(context).textTheme.bodyMedium,
                     textAlign: TextAlign.center,
                   ),
                   const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- display artist and track title separately on radio screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c724e899c08326a951b5bf8898d10c