### PR TITLE
feat: add quality selection popup

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -52,17 +52,31 @@ class _RadioView extends StatelessWidget {
                       Positioned(
                         top: 8,
                         right: 8,
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 8, vertical: 4),
-                          decoration: BoxDecoration(
-                            color: Colors.black54,
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Text(
-                            'HQ ${controller.quality}',
-                            style: const TextStyle(
-                                color: Colors.white, fontSize: 12),
+                        child: PopupMenuButton<String>(
+                          padding: EdgeInsets.zero,
+                          onSelected: (quality) {
+                            controller.setQuality(quality);
+                          },
+                          itemBuilder: (context) {
+                            return controller.streams.keys
+                                .map((quality) => PopupMenuItem<String>(
+                                      value: quality,
+                                      child: Text('HQ $quality'),
+                                    ))
+                                .toList();
+                          },
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: Colors.black54,
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Text(
+                              'HQ ${controller.quality}',
+                              style: const TextStyle(
+                                  color: Colors.white, fontSize: 12),
+                            ),
                           ),
                         ),
                       ),


### PR DESCRIPTION
## Summary
- add PopupMenuButton inside radio quality badge
- call controller.setQuality and update badge text
- build menu items from available streams for scalability

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c725a16c7c8326a127674418eacfc6