### PR TITLE
refactor radio layout to use safe column

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -22,141 +22,143 @@ class _RadioView extends StatelessWidget {
   Widget build(BuildContext context) {
     final controller = context.watch<RadioController>();
     final track = controller.track;
+    final size = MediaQuery.of(context).size.width * 0.6;
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final size = constraints.maxWidth * 0.6;
-        return Stack(
-          alignment: Alignment.topCenter,
-          children: [
-            Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Stack(
-                  children: [
-                    Container(
-                      width: size,
-                      height: size,
-                      decoration: BoxDecoration(
-                        image: DecorationImage(
-                          image: track != null && track.image.isNotEmpty
-                              ? NetworkImage(track.image)
-                              : const AssetImage(
-                                      'assets/images/Radio_RE_Logo.webp')
-                                  as ImageProvider,
-                          fit: BoxFit.cover,
-                        ),
-                      ),
-                    ),
-                    if (controller.quality != null)
-                      Positioned(
-                        top: 8,
-                        right: 8,
-                        child: PopupMenuButton<String>(
-                          padding: EdgeInsets.zero,
-                          onSelected: (quality) {
-                            controller.setQuality(quality);
-                          },
-                          itemBuilder: (context) {
-                            return controller.streams.keys
-                                .map((quality) => PopupMenuItem<String>(
-                                      value: quality,
-                                      child: Text('HQ $quality'),
-                                    ))
-                                .toList();
-                          },
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: Colors.black54,
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            child: Text(
-                              'HQ ${controller.quality}',
-                              style: const TextStyle(
-                                  color: Colors.white, fontSize: 12),
-                            ),
+    return SafeArea(
+      child: Column(
+        children: [
+          Expanded(
+            child: Align(
+              alignment: Alignment.center,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Stack(
+                    children: [
+                      Container(
+                        width: size,
+                        height: size,
+                        decoration: BoxDecoration(
+                          image: DecorationImage(
+                            image: track != null && track.image.isNotEmpty
+                                ? NetworkImage(track.image)
+                                : const AssetImage(
+                                        'assets/images/Radio_RE_Logo.webp')
+                                    as ImageProvider,
+                            fit: BoxFit.cover,
                           ),
                         ),
                       ),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                if (track != null) ...[
-                  Text(
-                    track.artist,
-                    style: Theme.of(context)
-                        .textTheme
-                        .headlineSmall
-                        ?.copyWith(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    track.title,
-                    style: Theme.of(context).textTheme.bodyMedium,
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 8),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 8, vertical: 2),
-                    decoration: BoxDecoration(
-                      color: Colors.red,
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: const Text(
-                      'LIVE',
-                      style: TextStyle(color: Colors.white, fontSize: 12),
-                    ),
+                      if (controller.quality != null)
+                        Align(
+                          alignment: Alignment.topRight,
+                          child: Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: PopupMenuButton<String>(
+                              padding: EdgeInsets.zero,
+                              onSelected: (quality) {
+                                controller.setQuality(quality);
+                              },
+                              itemBuilder: (context) {
+                                return controller.streams.keys
+                                    .map((quality) => PopupMenuItem<String>(
+                                          value: quality,
+                                          child: Text('HQ $quality'),
+                                        ))
+                                    .toList();
+                              },
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 8, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: Colors.black54,
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Text(
+                                  'HQ ${controller.quality}',
+                                  style: const TextStyle(
+                                      color: Colors.white, fontSize: 12),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
                   const SizedBox(height: 12),
-                ],
-                if (controller.hasError) ...[
-                  const Text(
-                    'Playback error. Press Play to try again.',
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 8),
-                ],
-              ],
-            ),
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      shape: const CircleBorder(),
-                      padding: const EdgeInsets.all(16),
+                  if (track != null) ...[
+                    Text(
+                      track.artist,
+                      style: Theme.of(context)
+                          .textTheme
+                          .headlineSmall
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                      textAlign: TextAlign.center,
                     ),
-                    onPressed: () =>
-                        context.read<RadioController>().togglePlay(),
-                    child: Icon(
-                      controller.playerState.playing
-                          ? Icons.pause
-                          : Icons.play_arrow,
+                    const SizedBox(height: 4),
+                    Text(
+                      track.title,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      textAlign: TextAlign.center,
                     ),
-                  ),
-                  const SizedBox(width: 16),
-                  IconButton(
-                    onPressed: () => _showVolumeDialog(context),
-                    icon: Icon(
-                      controller.volume == 0
-                          ? Icons.volume_off
-                          : Icons.volume_up,
+                    const SizedBox(height: 8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: Colors.red,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Text(
+                        'LIVE',
+                        style: TextStyle(color: Colors.white, fontSize: 12),
+                      ),
                     ),
-                  ),
+                    const SizedBox(height: 12),
+                  ],
+                  if (controller.hasError) ...[
+                    const Text(
+                      'Playback error. Press Play to try again.',
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                  ],
                 ],
               ),
             ),
-          ],
-        );
-      },
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    shape: const CircleBorder(),
+                    padding: const EdgeInsets.all(16),
+                  ),
+                  onPressed: () =>
+                      context.read<RadioController>().togglePlay(),
+                  child: Icon(
+                    controller.playerState.playing
+                        ? Icons.pause
+                        : Icons.play_arrow,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                IconButton(
+                  onPressed: () => _showVolumeDialog(context),
+                  icon: Icon(
+                    controller.volume == 0
+                        ? Icons.volume_off
+                        : Icons.volume_up,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- refactor radio screen with SafeArea and Column
- use Align instead of Positioned for quality menu
- anchor controls without Stack or LayoutBuilder

## Testing
- `flutter format lib/features/radio/radio_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `sudo apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c727fd0e9083268e5cec0e08ed24a2