### PR TITLE
Handle radio stream unavailability

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -21,6 +21,29 @@ class _RadioView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<RadioController>();
+    if (controller.streamsUnavailable) {
+      return SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'Radio streams are currently unavailable. Please try again later.',
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                ElevatedButton(
+                  onPressed: () => controller.init(),
+                  child: const Text('Retry'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
     final track = controller.track;
     final size = MediaQuery.of(context).size.width * 0.6;
 


### PR DESCRIPTION
## Summary
- Track when radio streams cannot be loaded and offer fallback URLs
- Surface the unavailable state to the UI with a retry option

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c728c4c7408326978a80271f3bfea7