### PR TITLE
Improve radio playback error handling

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -140,8 +140,9 @@ class _RadioView extends StatelessWidget {
                     const SizedBox(height: 12),
                   ],
                   if (controller.hasError) ...[
-                    const Text(
-                      'Playback error. Press Play to try again.',
+                    Text(
+                      controller.errorMessage ??
+                          'Playback error. Press Play to try again.',
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- Catch AudioService and AudioPlayer errors when initializing and starting radio streams
- Expose descriptive playback error messages to the UI
- Add logging hook for diagnosing playback failures

## Testing
- `flutter format lib/features/radio/radio_controller.dart lib/features/radio/radio_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72a7e34808326a5b5ad30b0dfae1b