### PR TITLE
Avoid double AudioService initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:just_audio_background/just_audio_background.dart';
 
 import 'app.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await JustAudioBackground.init(
-    androidNotificationChannelId: 'm_club_radio_channel',
-    androidNotificationChannelName: 'M-Club Radio',
-    androidNotificationIcon: 'assets/images/Radio_RE_Logo.webp',
-    androidNotificationOngoing: true,
-  );
   runApp(const MyApp());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,6 @@ dependencies:
   # Мультимедиа и ссылки
   just_audio: ^0.9.38
   audio_service: ^0.18.18
-  just_audio_background: ^0.0.1-beta.17
   url_launcher: ^6.3.0
 
   # UI


### PR DESCRIPTION
## Summary
- remove JustAudioBackground init in main entrypoint
- drop unused just_audio_background dependency

## Testing
- `flutter analyze && flutter test` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72be44f9c83269e7710af925c1b6d