### PR TITLE
feat: improve radio player states

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -59,6 +59,17 @@ class RadioController extends ChangeNotifier {
   double get volume => _volume;
   String? get errorMessage => _errorMessage;
 
+  bool get isConnecting =>
+      _playerState.processingState == ProcessingState.loading;
+  bool get isBuffering =>
+      _playerState.processingState == ProcessingState.buffering;
+  bool get isPlaying =>
+      _playerState.playing &&
+      _playerState.processingState == ProcessingState.ready;
+  bool get isPaused =>
+      !_playerState.playing &&
+      _playerState.processingState == ProcessingState.ready;
+
   /// Starts playback if the stream is not playing and stops otherwise.
   Future<void> togglePlay() async {
     await _audioHandlerReady;
@@ -95,6 +106,18 @@ class RadioController extends ChangeNotifier {
       _volume = _previousVolume;
     }
     await _player.setVolume(_volume);
+    notifyListeners();
+  }
+
+  /// Retries playback of the current stream.
+  Future<void> retry() async {
+    _hasError = false;
+    _errorMessage = null;
+    if (_streams.isEmpty) {
+      await init(quality: _quality);
+    } else {
+      await _startStream();
+    }
     notifyListeners();
   }
 

--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -141,6 +141,18 @@ class _RadioView extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 16),
+                  if (controller.hasError) ...[
+                    Chip(
+                      label: const Text('ERROR'),
+                      labelStyle: const TextStyle(color: Colors.white),
+                      backgroundColor: Colors.red,
+                    ),
+                    TextButton(
+                      onPressed: () => context.read<RadioController>().retry(),
+                      child: const Text('Повторить'),
+                    ),
+                    const SizedBox(height: 16),
+                  ],
                   if (track != null) ...[
                     Text(
                       track.artist,
@@ -171,14 +183,6 @@ class _RadioView extends StatelessWidget {
                     ),
                     const SizedBox(height: 24),
                   ],
-                  if (controller.hasError) ...[
-                    Text(
-                      controller.errorMessage ??
-                          'Playback error. Press Play to try again.',
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-                  ],
                 ],
               ),
             ),
@@ -188,26 +192,49 @@ class _RadioView extends StatelessWidget {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    shape: const CircleBorder(),
-                    padding: const EdgeInsets.all(20),
-                    minimumSize: const Size(64, 64),
-                  ),
-                  onPressed: () =>
-                      context.read<RadioController>().togglePlay(),
-                  child: Icon(
-                    controller.playerState.playing
-                        ? Icons.pause
-                        : Icons.play_arrow,
-                  ),
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        shape: const CircleBorder(),
+                        padding: const EdgeInsets.all(20),
+                        minimumSize: const Size(64, 64),
+                      ),
+                      onPressed: () =>
+                          context.read<RadioController>().togglePlay(),
+                      child: controller.isConnecting || controller.isBuffering
+                          ? const SizedBox(
+                              width: 24,
+                              height: 24,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : Icon(
+                              controller.isPlaying
+                                  ? Icons.pause
+                                  : Icons.play_arrow,
+                            ),
+                    ),
+                    if (controller.isConnecting)
+                      const Padding(
+                        padding: EdgeInsets.only(top: 8.0),
+                        child: Text('Подключаемся…'),
+                      ),
+                    if (controller.isBuffering)
+                      const Padding(
+                        padding: EdgeInsets.only(top: 8.0),
+                        child: Text('Буферизация…'),
+                      ),
+                  ],
                 ),
                 const SizedBox(width: 16),
                 IconButton(
-                  constraints: const BoxConstraints(
-                      minWidth: 44, minHeight: 44),
-                  onPressed: () =>
-                      context.read<RadioController>().toggleMute(),
+                  constraints:
+                      const BoxConstraints(minWidth: 44, minHeight: 44),
+                  onPressed: controller.isConnecting || controller.isBuffering
+                      ? null
+                      : () =>
+                          context.read<RadioController>().toggleMute(),
                   icon: Icon(
                     controller.volume == 0
                         ? Icons.volume_off


### PR DESCRIPTION
## Summary
- expose playback state getters and retry in `RadioController`
- show loading/buffering indicators and retry chip on radio screen

## Testing
- `dart format lib/features/radio/radio_controller.dart lib/features/radio/radio_screen.dart` *(fails: command not found)*
- `flutter format lib/features/radio/radio_controller.dart lib/features/radio/radio_screen.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73998aaa88326bb248be202e619e7