### PR TITLE
feat: add stream quality selector

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -102,7 +102,7 @@ class _RadioView extends StatelessWidget {
                                           mainAxisSize: MainAxisSize.min,
                                           children: controller.streams.keys
                                               .map((quality) => ListTile(
-                                                    title: Text('HQ $quality'),
+                                                    title: Text(quality),
                                                     trailing:
                                                         controller.quality ==
                                                                 quality
@@ -128,7 +128,7 @@ class _RadioView extends StatelessWidget {
                                       horizontal: 8, vertical: 4),
                                   child: Center(
                                     child: Text(
-                                      'HQ ${controller.quality}',
+                                      controller.quality!,
                                       style: const TextStyle(
                                           color: Colors.white, fontSize: 12),
                                     ),


### PR DESCRIPTION
## Summary
- overlay current stream quality on radio artwork
- provide bottom sheet selector to switch stream quality

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73a6a4ec083268aaa854115418130