### PR TITLE
Increase radio artwork size

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -56,7 +56,7 @@ class _RadioView extends StatelessWidget {
                       constraints.maxWidth,
                       constraints.maxHeight,
                     ) *
-                    0.6;
+                    0.8;
                 return Align(
                   alignment: Alignment.center,
                   child: Column(

--- a/test/radio_screen_layout_test.dart
+++ b/test/radio_screen_layout_test.dart
@@ -12,7 +12,7 @@ class _TestRadioArtwork extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final size =
-            math.min(constraints.maxWidth, constraints.maxHeight) * 0.6;
+            math.min(constraints.maxWidth, constraints.maxHeight) * 0.8;
         return Center(
           child: SizedBox(
             width: size,


### PR DESCRIPTION
## Summary
- enlarge radio artwork container to 80% of the smaller screen dimension
- adjust layout test to match new artwork sizing

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7431375488326850660c12a7cff95