### PR TITLE
Enlarge radio controls

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -213,8 +213,8 @@ class _RadioView extends StatelessWidget {
                         ElevatedButton(
                           style: ElevatedButton.styleFrom(
                             shape: const CircleBorder(),
-                            padding: const EdgeInsets.all(20),
-                            minimumSize: const Size(64, 64),
+                            padding: const EdgeInsets.all(16),
+                            minimumSize: const Size(72, 72),
                           ),
                           onPressed: () =>
                               context.read<RadioController>().togglePlay(),
@@ -230,6 +230,7 @@ class _RadioView extends StatelessWidget {
                                   controller.isPlaying
                                       ? Icons.pause
                                       : Icons.play_arrow,
+                                  size: 36,
                                 ),
                         ),
                         if (controller.isConnecting)
@@ -249,7 +250,8 @@ class _RadioView extends StatelessWidget {
                     alignment: const Alignment(0.5, 0),
                     child: IconButton(
                       constraints:
-                          const BoxConstraints(minWidth: 44, minHeight: 44),
+                          const BoxConstraints(minWidth: 60, minHeight: 60),
+                      iconSize: 36,
                       onPressed: controller.isConnecting ||
                               controller.isBuffering
                           ? null


### PR DESCRIPTION
## Summary
- Enlarge radio play/pause button icon
- Make mute icon larger and adjust button sizes

## Testing
- ⚠️ `dart format lib/features/radio/radio_screen.dart` (command not found)
- ⚠️ `flutter test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c7468a53808326988a29481416d2e1