### PR TITLE
Fix border radius for radio artwork

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -69,8 +69,7 @@ class _RadioView extends StatelessWidget {
                       Stack(
                         children: [
                           ClipRRect(
-                            borderRadius: const BorderRadius.vertical(
-                                top: Radius.circular(24)),
+                            borderRadius: BorderRadius.circular(24),
                             child: SizedBox(
                               width: size,
                               height: size,


### PR DESCRIPTION
## Summary
- use uniform 24px border radius for radio artwork

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c74ab98154832686263fad30b430cc