### PR TITLE
style: enlarge radio title text

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -169,7 +169,7 @@ class _RadioView extends StatelessWidget {
                       const SizedBox(height: 8),
                       Text(
                         title,
-                        style: Theme.of(context).textTheme.titleMedium,
+                        style: Theme.of(context).textTheme.titleLarge,
                         textAlign: TextAlign.center,
                         softWrap: true,
                       ),


### PR DESCRIPTION
## Summary
- use `titleLarge` for radio track title for better visibility

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c74bb23ccc83268556dcf1e255f42d