### PR TITLE
Persist radio audio across screens

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -9,10 +9,7 @@ class RadioScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => RadioController()..init(),
-      child: const _RadioView(),
-    );
+    return const _RadioView();
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import 'app.dart';
+import 'features/radio/radio_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(const MyApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => RadioController()..init(),
+      child: const MyApp(),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
- Provide `RadioController` at application root so it survives screen changes
- Reuse a singleton `AudioPlayer` and `AudioHandler` for radio playback
- Keep audio playing in background by not disposing the shared player

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c750877b188326bad36772e5b1781e