### PR TITLE
Reduce radio track refresh interval and leverage metadata

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -25,6 +25,13 @@ class RadioController extends ChangeNotifier {
       }
       notifyListeners();
     });
+
+    // Listen to ICY metadata updates to refresh track information as soon
+    // as the streaming server reports new data. This supplements the
+    // periodic timer-based refresh below.
+    _player.icyMetadataStream.listen((_) {
+      _updateTrackInfo();
+    });
   }
 
   final RadioApiService _api = RadioApiService();
@@ -208,7 +215,7 @@ class RadioController extends ChangeNotifier {
 
   void _startTrackInfoTimer() {
     _trackTimer?.cancel();
-    _trackTimer = Timer.periodic(const Duration(seconds: 30), (_) {
+    _trackTimer = Timer.periodic(const Duration(seconds: 10), (_) {
       _updateTrackInfo();
     });
   }


### PR DESCRIPTION
## Summary
- Decrease radio track refresh timer from 30s to 10s
- Listen for just_audio ICY metadata to refresh track info immediately

## Testing
- `dart format lib/features/radio/radio_controller.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c751ddc22c83269b406d62070ac4de