### PR TITLE
Ensure AudioService starts once and reconnects

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,9 +6,12 @@ import 'features/radio/radio_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  final radioController = RadioController();
+  await radioController.ensureAudioService();
+  radioController.init();
   runApp(
-    ChangeNotifierProvider(
-      create: (_) => RadioController()..init(),
+    ChangeNotifierProvider.value(
+      value: radioController,
       child: const MyApp(),
     ),
   );


### PR DESCRIPTION
## Summary
- make `RadioController` a singleton and expose `ensureAudioService` to initialize `AudioService` once
- bootstrap `AudioService` before `runApp` for reconnection after app restart

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c7529c3e8c83269f801b62903b7be6