### PR TITLE
Fix playback state handling in radio audio handler

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -282,7 +282,9 @@ class RadioController extends ChangeNotifier {
 
 class _RadioAudioHandler extends BaseAudioHandler with SeekHandler {
   _RadioAudioHandler(this._player) {
-    _player.playbackEventStream.map(_transformEvent).pipe(playbackState);
+    _player.playbackEventStream
+        .map(_transformEvent)
+        .listen(playbackState.add);
   }
 
   final AudioPlayer _player;
@@ -341,7 +343,6 @@ class _RadioAudioHandler extends BaseAudioHandler with SeekHandler {
   @override
   Future<void> stop() async {
     await _player.stop();
-    await super.stop();
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace pipe with listen to update playbackState using add
- Remove super.stop call to rely solely on player stop

## Testing
- `dart format lib/features/radio/radio_controller.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7565760e483269134e882959f5896