### PR TITLE
feat(radio): show placeholder metadata on stream start

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -182,6 +182,13 @@ class RadioController extends ChangeNotifier {
     try {
       await _audioHandler!.stop();
       await _player.setUrl(url);
+      (_audioHandler! as _RadioAudioHandler).updateTrack(
+        RadioTrack(
+          artist: '',
+          title: 'Радио «Русские Эмираты»',
+          image: '',
+        ),
+      );
       await _audioHandler!.play();
       await _updateTrackInfo();
       notifyListeners();
@@ -225,11 +232,30 @@ class RadioController extends ChangeNotifier {
     await _audioHandlerReady;
     try {
       final info = await _api.fetchTrackInfo();
-      if (info == null) return;
+      if (info == null) {
+        _track = null;
+        (_audioHandler! as _RadioAudioHandler).updateTrack(
+          RadioTrack(
+            artist: '',
+            title: 'Радио «Русские Эмираты»',
+            image: '',
+          ),
+        );
+        notifyListeners();
+        return;
+      }
       _track = info;
       (_audioHandler! as _RadioAudioHandler).updateTrack(info);
       notifyListeners();
     } catch (_) {
+      _track = null;
+      (_audioHandler! as _RadioAudioHandler).updateTrack(
+        RadioTrack(
+          artist: '',
+          title: 'Радио «Русские Эмираты»',
+          image: '',
+        ),
+      );
       // ignore errors
     }
   }


### PR DESCRIPTION
## Summary
- ensure media notification displays immediately by setting placeholder track before fetching metadata
- populate notification with station name and default icon when track info is unavailable

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c75e4a121c8326b113a2dd787a0ee1