### PR TITLE
feat: configure audio session for radio playback

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:audio_service/audio_service.dart';
+import 'package:audio_session/audio_session.dart';
 import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:m_club/core/services/radio_api_service.dart';
@@ -283,6 +284,10 @@ class RadioController extends ChangeNotifier {
       return;
     }
     try {
+      final session = await AudioSession.instance;
+      await session.configure(const AudioSessionConfiguration.music());
+      await session.setActive(true);
+
       _audioHandler = await AudioService.init(
         builder: () => _RadioAudioHandler(_player),
         config: const AudioServiceConfig(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "0.1.4"
   audio_session:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: audio_session
       sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   # Мультимедиа и ссылки
   just_audio: ^0.9.38
   audio_service: ^0.18.18
+  audio_session: ^0.1.25
   url_launcher: ^6.3.0
 
   # UI


### PR DESCRIPTION
## Summary
- configure an audio session before initializing audio service
- declare audio_session dependency

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7615d4ebc83269b839b4082ddde15