### PR TITLE
Ensure audio session active for radio playback

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -190,6 +190,8 @@ class RadioController extends ChangeNotifier {
           image: '',
         ),
       );
+      final session = await AudioSession.instance;
+      await session.setActive(true);
       await _audioHandler!.play();
       await _updateTrackInfo();
       notifyListeners();
@@ -374,6 +376,8 @@ class _RadioAudioHandler extends BaseAudioHandler with SeekHandler {
   @override
   Future<void> stop() async {
     await _player.stop();
+    final session = await AudioSession.instance;
+    await session.setActive(false);
   }
 }
 


### PR DESCRIPTION
## Summary
- Activate `AudioSession` before starting radio playback
- Deactivate the audio session when stopping the radio

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c7678b5a00832689fd2da38401c870