### PR TITLE
Initialize radio track after audio handler setup

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -299,6 +299,13 @@ class RadioController extends ChangeNotifier {
           androidNotificationOngoing: true,
         ),
       );
+      (_audioHandler! as _RadioAudioHandler).updateTrack(
+        RadioTrack(
+          artist: '',
+          title: 'Радио «Русские Эмираты»',
+          image: '',
+        ),
+      );
     } catch (e, s) {
       _hasError = true;
       _errorMessage = 'Audio service error: ${e.toString()}';


### PR DESCRIPTION
## Summary
- Initialize radio's default track immediately after AudioService setup

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c768548b68832695c28ae751987aca