### PR TITLE
feat: add stop method for radio controller

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -97,6 +97,14 @@ class RadioController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Completely stops playback and releases audio resources.
+  Future<void> stop() async {
+    await _audioHandlerReady;
+    _trackTimer?.cancel();
+    await _audioHandler!.stop();
+    notifyListeners();
+  }
+
   /// Sets the player volume to a value between 0.0 and 1.0.
   Future<void> setVolume(double value) async {
     _volume = value.clamp(0.0, 1.0);


### PR DESCRIPTION
## Summary
- add explicit stop method to update notification state

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c77c38e3d48326a04d3285aaa11863