### PR TITLE
feat: integrate audio service state updates

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -280,6 +280,12 @@ class RadioController extends ChangeNotifier {
   @override
   void dispose() {
     _trackTimer?.cancel();
+    // Stop the background service only when nothing is playing to
+    // release resources while still allowing ongoing playback to
+    // continue when the UI is closed.
+    if (!_player.playing) {
+      _audioHandler?.stop();
+    }
     super.dispose();
   }
 

--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -13,8 +13,22 @@ class RadioScreen extends StatelessWidget {
   }
 }
 
-class _RadioView extends StatelessWidget {
+class _RadioView extends StatefulWidget {
   const _RadioView();
+
+  @override
+  State<_RadioView> createState() => _RadioViewState();
+}
+
+class _RadioViewState extends State<_RadioView> {
+  @override
+  void initState() {
+    super.initState();
+    // Ensure that the UI always connects to an existing audio service
+    // when the radio screen is opened, even after process restarts.
+    final controller = context.read<RadioController>();
+    controller.ensureAudioService();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -262,16 +276,29 @@ class _RadioView extends StatelessWidget {
                             ),
                           ],
                         ),
-                        if (controller.isConnecting)
-                          const Padding(
-                            padding: EdgeInsets.only(top: 8.0),
-                            child: Text('Подключаемся…'),
-                          ),
-                        if (controller.isBuffering)
-                          const Padding(
-                            padding: EdgeInsets.only(top: 8.0),
-                            child: Text('Буферизация…'),
-                          ),
+                        Consumer<RadioController>(
+                          builder: (context, state, _) {
+                            if (state.isBuffering) {
+                              return const Padding(
+                                padding: EdgeInsets.only(top: 8.0),
+                                child: Text('Буферизация…'),
+                              );
+                            }
+                            if (state.isPlaying) {
+                              return const Padding(
+                                padding: EdgeInsets.only(top: 8.0),
+                                child: Text('Воспроизведение'),
+                              );
+                            }
+                            if (state.isPaused) {
+                              return const Padding(
+                                padding: EdgeInsets.only(top: 8.0),
+                                child: Text('Пауза'),
+                              );
+                            }
+                            return const SizedBox.shrink();
+                          },
+                        ),
                       ],
                     ),
                   ),


### PR DESCRIPTION
## Summary
- ensure radio screen reconnects to existing audio service
- show playback state via Provider and keep service running when UI closes

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7829fd8508326bbd6b49e3d9cf30f