### PR TITLE
Add notification permission check before starting radio audio service

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -22,15 +22,6 @@ class _RadioView extends StatefulWidget {
 
 class _RadioViewState extends State<_RadioView> {
   @override
-  void initState() {
-    super.initState();
-    // Ensure that the UI always connects to an existing audio service
-    // when the radio screen is opened, even after process restarts.
-    final controller = context.read<RadioController>();
-    controller.ensureAudioService();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final controller = context.watch<RadioController>();
     if (controller.streamsUnavailable) {
@@ -46,10 +37,11 @@ class _RadioViewState extends State<_RadioView> {
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 12),
-                ElevatedButton(
-                  onPressed: () => controller.init(),
-                  child: const Text('Retry'),
-                ),
+                  ElevatedButton(
+                    onPressed: () => controller
+                        .init(startService: controller.notificationsEnabled),
+                    child: const Text('Retry'),
+                  ),
               ],
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,8 +7,6 @@ import 'features/radio/radio_controller.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final radioController = RadioController();
-  await radioController.ensureAudioService();
-  radioController.init();
   runApp(
     ChangeNotifierProvider.value(
       value: radioController,


### PR DESCRIPTION
## Summary
- request POST_NOTIFICATIONS on Android 13+ before initializing radio service
- allow RadioController to skip service startup and track notification availability
- show user a snackbar when notification permission is denied

## Testing
- `dart format lib/main.dart lib/app.dart lib/features/radio/radio_controller.dart lib/features/radio/radio_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c78b63c95c8326940b74a10514c0f0