### PR TITLE
Handle iOS audio session activation

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -10,10 +10,14 @@ import AVFoundation
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     do {
-      try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+      try AVAudioSession.sharedInstance().setCategory(.playback)
+    } catch {
+      print("Failed to set audio session category: \(error)")
+    }
+    do {
       try AVAudioSession.sharedInstance().setActive(true)
     } catch {
-      print("Failed to configure audio session: \(error)")
+      print("Failed to activate audio session: \(error)")
     }
     application.beginReceivingRemoteControlEvents()
     GMSServices.provideAPIKey("AIzaSyCWGXrDv1nBR5YWb4M2OTFcmwbPX7carIM")

--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -218,7 +218,11 @@ class RadioController extends ChangeNotifier {
         ),
       );
       final session = await AudioSession.instance;
-      await session.setActive(true);
+      try {
+        await session.setActive(true);
+      } catch (e, s) {
+        _logPlaybackFailure('activateSession', e, s);
+      }
       await _audioHandler!.play();
       _startTrackInfoTimer();
       await _updateTrackInfo();


### PR DESCRIPTION
## Summary
- log audio session category and activation failures in `AppDelegate`
- log activation errors when starting radio playback

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c78f30317c8326b7495da7d96e3243