### PR TITLE
Add provider import to app for context read

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:provider/provider.dart';
 
 import 'features/home/home_screen.dart';
 import 'core/widgets/auth_gate.dart';


### PR DESCRIPTION
## Summary
- import provider package in app.dart so context.read works

## Testing
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bb2886108326b109c69a171647d4