### PR TITLE
Explicit playback controls and system actions

### DIFF
--- a/lib/features/radio/radio_audio_handler.dart
+++ b/lib/features/radio/radio_audio_handler.dart
@@ -7,6 +7,13 @@ import 'package:m_club/features/radio/models/radio_track.dart';
 class RadioAudioHandler extends BaseAudioHandler with SeekHandler {
   RadioAudioHandler(this._player) {
     _player.playbackEventStream.map(_transformEvent).listen(playbackState.add);
+    setSystemActions(
+      const {
+        MediaAction.play,
+        MediaAction.pause,
+        MediaAction.stop,
+      },
+    );
   }
 
   final AudioPlayer _player;
@@ -38,14 +45,15 @@ class RadioAudioHandler extends BaseAudioHandler with SeekHandler {
     debugPrint(
       'Playback event - playing: $playing, processingState: ${event.processingState}',
     );
-    final controls = <MediaControl>[
-      if (playing) MediaControl.pause else MediaControl.play,
+    const controls = <MediaControl>[
+      MediaControl.play,
+      MediaControl.pause,
       MediaControl.stop,
     ];
 
     return PlaybackState(
       controls: controls,
-      androidCompactActionIndices: const [0, 1],
+      androidCompactActionIndices: const [0, 1, 2],
       processingState: const {
         ProcessingState.idle: AudioProcessingState.idle,
         ProcessingState.loading: AudioProcessingState.loading,


### PR DESCRIPTION
## Summary
- Always expose play, pause, and stop controls in the radio audio handler
- Declare supported system actions for play, pause, and stop
- Ensure compact Android actions include all controls

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c4a5f390832690025edd3e9326db