### PR TITLE
Fix fallback artwork URI for radio

### DIFF
--- a/lib/features/radio/radio_audio_handler.dart
+++ b/lib/features/radio/radio_audio_handler.dart
@@ -1,6 +1,7 @@
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:m_club/features/radio/models/radio_track.dart';
 
@@ -12,7 +13,7 @@ class RadioAudioHandler extends BaseAudioHandler with SeekHandler {
   final AudioPlayer _player;
 
   /// Updates the current track information for external clients.
-  void updateTrack(RadioTrack track) {
+  Future<void> updateTrack(RadioTrack track) async {
     debugPrint('Updating track: ${track.title} - ${track.artist}');
     Uri? artUri;
     if (track.image.isNotEmpty) {
@@ -21,7 +22,13 @@ class RadioAudioHandler extends BaseAudioHandler with SeekHandler {
         artUri = uri;
       }
     }
-    artUri ??= Uri.parse('asset:///assets/images/Radio_RE_Logo.webp');
+    if (artUri == null) {
+      final byteData = await rootBundle.load('assets/images/Radio_RE_Logo.webp');
+      artUri = Uri.dataFromBytes(
+        byteData.buffer.asUint8List(),
+        mimeType: 'image/webp',
+      );
+    }
 
     mediaItem.add(
       MediaItem(

--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -210,7 +210,7 @@ class RadioController extends ChangeNotifier {
     try {
       await _audioHandler!.stop();
       await _player.setUrl(url);
-      _audioHandler!.updateTrack(
+      await _audioHandler!.updateTrack(
         RadioTrack(
           artist: '',
           title: 'Радио «Русские Эмираты»',
@@ -270,7 +270,7 @@ class RadioController extends ChangeNotifier {
       final info = await _api.fetchTrackInfo();
       if (info == null) {
         _track = null;
-        _audioHandler!.updateTrack(
+        await _audioHandler!.updateTrack(
           RadioTrack(
             artist: '',
             title: 'Радио «Русские Эмираты»',
@@ -281,11 +281,11 @@ class RadioController extends ChangeNotifier {
         return;
       }
       _track = info;
-      _audioHandler!.updateTrack(info);
+      await _audioHandler!.updateTrack(info);
       notifyListeners();
     } catch (_) {
       _track = null;
-      _audioHandler!.updateTrack(
+      await _audioHandler!.updateTrack(
         RadioTrack(
           artist: '',
           title: 'Радио «Русские Эмираты»',
@@ -334,7 +334,7 @@ class RadioController extends ChangeNotifier {
           androidNotificationOngoing: true,
         ),
       ) as RadioAudioHandler;
-      _audioHandler!.updateTrack(
+      await _audioHandler!.updateTrack(
         RadioTrack(
           artist: '',
           title: 'Радио «Русские Эмираты»',


### PR DESCRIPTION
## Summary
- load radio fallback artwork from bundled asset and expose as data URI
- await updated `RadioAudioHandler.updateTrack` async calls

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ce7680e083268185f3ffcedc7fc8