### PR TITLE
feat: update radio notification icon

### DIFF
--- a/lib/features/radio/radio_audio_handler.dart
+++ b/lib/features/radio/radio_audio_handler.dart
@@ -23,10 +23,11 @@ class RadioAudioHandler extends BaseAudioHandler with SeekHandler {
       }
     }
     if (artUri == null) {
-      final byteData = await rootBundle.load('assets/images/Radio_RE_Logo.webp');
+      final byteData =
+          await rootBundle.load('assets/images/radio_notification_icon.png');
       artUri = Uri.dataFromBytes(
         byteData.buffer.asUint8List(),
-        mimeType: 'image/webp',
+        mimeType: 'image/png',
       );
     }
 


### PR DESCRIPTION
## Summary
- load new PNG notification icon for radio fallback art
- rely on existing `radio_notification_icon.png` asset without committing binary

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d62a71988326b2addcf5a8be5f3c