### PR TITLE
fix: update just_audio_background version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -461,6 +461,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.46"
+  just_audio_background:
+    dependency: "direct main"
+    description:
+      name: just_audio_background
+      sha256: "3900825701164577db65337792bc122b66f9eb1245ee47e7ae8244ae5ceb8030"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1-beta.17"
   just_audio_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   just_audio: ^0.9.46
   audio_service: ^0.18.18
   audio_session: ^0.1.25
-  just_audio_background: ^0.0.latest
+  just_audio_background: ^0.0.1-beta.17
   url_launcher: ^6.3.0
 
   # UI


### PR DESCRIPTION
## Summary
- replace placeholder `just_audio_background` dependency with latest valid release
- run `flutter pub get` to refresh dependencies

## Testing
- `flutter pub get`

------
https://chatgpt.com/codex/tasks/task_e_68c80ea2034c83268e103dd2f5af3179