### PR TITLE
Use AudioServiceActivity for MainActivity

### DIFF
--- a/android/app/src/main/kotlin/com/mclub/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mclub/app/MainActivity.kt
@@ -1,5 +1,5 @@
 package com.mclub.app
 
-import io.flutter.embedding.android.FlutterActivity
+import com.ryanheise.audioservice.AudioServiceActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : AudioServiceActivity()


### PR DESCRIPTION
## Summary
- update the Android MainActivity to extend AudioServiceActivity so the audio service plugin can initialize correctly

## Testing
- `flutter build apk` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c95f34d3308326adab222e570f51f5