### PR TITLE
Ensure audio service guard checks running state

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -315,7 +315,7 @@ class RadioController extends ChangeNotifier {
   /// This is useful when the app process restarts and needs to
   /// reconnect to a running background audio service.
   Future<void> ensureAudioService() async {
-    if (AudioService.connected == true && _audioHandler != null) {
+    if (AudioService.running == true && _audioHandler != null) {
       _resetAudioHandlerCompleter();
       _completeAudioHandlerCompleter();
       return;


### PR DESCRIPTION
## Summary
- update the audio service initialization guard to only return when the service is running
- keep the initialization path available when a handler exists but the service is not running

## Testing
- flutter analyze *(fails: `flutter` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c977b3f2c483268a83d814d796cd82