### PR TITLE
Fix audio service reinitialization

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -43,9 +43,10 @@ class RadioController extends ChangeNotifier {
   final RadioApiService _api = RadioApiService();
   static final AudioPlayer _player = AudioPlayer();
   static RadioAudioHandler? _audioHandler;
-  final Completer<void> _audioHandlerCompleter = Completer<void>();
+  Completer<void>? _audioHandlerCompleter;
 
-  Future<void> get _audioHandlerReady => _audioHandlerCompleter.future;
+  Future<void> get _audioHandlerReady =>
+      (_audioHandlerCompleter ??= Completer<void>()).future;
 
   Map<String, String> _streams = {};
   String? _quality;
@@ -158,9 +159,8 @@ class RadioController extends ChangeNotifier {
       }
     } else {
       _audioHandler ??= RadioAudioHandler(_player);
-      if (!_audioHandlerCompleter.isCompleted) {
-        _audioHandlerCompleter.complete();
-      }
+      _resetAudioHandlerCompleter();
+      _completeAudioHandlerCompleter();
     }
 
     _streamsUnavailable = false;
@@ -315,12 +315,15 @@ class RadioController extends ChangeNotifier {
   /// This is useful when the app process restarts and needs to
   /// reconnect to a running background audio service.
   Future<void> ensureAudioService() async {
-    if (_audioHandler != null) {
-      if (!_audioHandlerCompleter.isCompleted) {
-        _audioHandlerCompleter.complete();
-      }
+    if (_audioHandler != null &&
+        AudioService.connectionState ==
+            AudioServiceConnectionState.connected) {
+      _resetAudioHandlerCompleter();
+      _completeAudioHandlerCompleter();
       return;
     }
+
+    _resetAudioHandlerCompleter();
     try {
       final session = await AudioSession.instance;
       await session.configure(const AudioSessionConfiguration.music());
@@ -348,8 +351,19 @@ class RadioController extends ChangeNotifier {
       _logPlaybackFailure('ensureAudioService', e, s);
       _audioHandler ??= RadioAudioHandler(_player);
     }
-    if (!_audioHandlerCompleter.isCompleted) {
-      _audioHandlerCompleter.complete();
+    _completeAudioHandlerCompleter();
+  }
+
+  void _resetAudioHandlerCompleter() {
+    if (_audioHandlerCompleter == null || _audioHandlerCompleter!.isCompleted) {
+      _audioHandlerCompleter = Completer<void>();
+    }
+  }
+
+  void _completeAudioHandlerCompleter() {
+    final completer = _audioHandlerCompleter;
+    if (completer != null && !completer.isCompleted) {
+      completer.complete();
     }
   }
 


### PR DESCRIPTION
## Summary
- rebuild the audio handler completer when the service is reinitialized so callers wait for readiness
- re-run AudioService.init when the handler exists but the service connection dropped instead of returning early
- avoid AudioService.running cast error by checking connectionState directly

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9729319ec832686d4edd199546f2a