### PR TITLE
Adjust radio audio service startup logic

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -315,10 +315,7 @@ class RadioController extends ChangeNotifier {
   /// This is useful when the app process restarts and needs to
   /// reconnect to a running background audio service.
   Future<void> ensureAudioService() async {
-    final isConnected = AudioService.playbackStateStream.hasValue &&
-        AudioService.playbackStateStream.value.processingState !=
-            AudioProcessingState.idle;
-    if (isConnected && _audioHandler != null) {
+    if (AudioService.connected && _audioHandler != null) {
       _resetAudioHandlerCompleter();
       _completeAudioHandlerCompleter();
       return;
@@ -330,7 +327,7 @@ class RadioController extends ChangeNotifier {
       await session.configure(const AudioSessionConfiguration.music());
       await session.setActive(true);
 
-      if (_audioHandler == null || !isConnected) {
+      if (_audioHandler == null || !AudioService.connected) {
         _audioHandler = await AudioService.init(
           builder: () => RadioAudioHandler(_player),
           config: const AudioServiceConfig(

--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -33,7 +33,6 @@ class _RadioViewState extends State<_RadioView> {
 
   Future<void> _ensureServiceAndPlay() async {
     final controller = context.read<RadioController>();
-    var startService = true;
 
     if (Platform.isAndroid) {
       final androidInfo = await DeviceInfoPlugin().androidInfo;
@@ -43,7 +42,6 @@ class _RadioViewState extends State<_RadioView> {
           status = await Permission.notification.request();
         }
         if (!status.isGranted) {
-          startService = false;
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(
@@ -53,16 +51,15 @@ class _RadioViewState extends State<_RadioView> {
               ),
             );
           }
+          return;
         }
       }
     }
 
-    if (startService) {
-      if (!controller.notificationsEnabled) {
-        await controller.init(startService: true);
-      } else {
-        await controller.ensureAudioService();
-      }
+    if (!controller.notificationsEnabled) {
+      await controller.init(startService: true);
+    } else {
+      await controller.ensureAudioService();
     }
 
     await controller.togglePlay();


### PR DESCRIPTION
## Summary
- ensure the radio service only starts after notification permission has been granted
- start or reconnect the audio service on demand before toggling playback, reinitializing when the connection drops

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c980def4708326aa7bab741703c13c