### PR TITLE
Update audio service running checks

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -315,7 +315,7 @@ class RadioController extends ChangeNotifier {
   /// This is useful when the app process restarts and needs to
   /// reconnect to a running background audio service.
   Future<void> ensureAudioService() async {
-    if (AudioService.connected && _audioHandler != null) {
+    if (AudioService.running && _audioHandler != null) {
       _resetAudioHandlerCompleter();
       _completeAudioHandlerCompleter();
       return;
@@ -327,7 +327,7 @@ class RadioController extends ChangeNotifier {
       await session.configure(const AudioSessionConfiguration.music());
       await session.setActive(true);
 
-      if (_audioHandler == null || !AudioService.connected) {
+      if (_audioHandler == null || !AudioService.running) {
         _audioHandler = await AudioService.init(
           builder: () => RadioAudioHandler(_player),
           config: const AudioServiceConfig(


### PR DESCRIPTION
## Summary
- switch AudioService checks from `connected` to `running` in the radio controller to match the updated API
- keep the early return guarded by both a running service and an initialized handler

## Testing
- `flutter build apk` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c9865bdcdc83268f9e3b93aba9b6aa