### PR TITLE
Avoid tearing down running radio service

### DIFF
--- a/lib/features/radio/radio_screen.dart
+++ b/lib/features/radio/radio_screen.dart
@@ -28,7 +28,8 @@ class _RadioViewState extends State<_RadioView> {
   @override
   void initState() {
     super.initState();
-    context.read<RadioController>().init(startService: false);
+    final controller = context.read<RadioController>();
+    controller.init(startService: controller.notificationsEnabled);
   }
 
   Future<void> _ensureServiceAndPlay() async {


### PR DESCRIPTION
## Summary
- keep the persisted background radio handler alive when init is called while the service is already running
- respect the stored notification preference when re-entering the radio screen to avoid toggling the service state

## Testing
- `flutter analyze` *(fails: Flutter is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9aebdbcf0832695ad84991daccfcf