### PR TITLE
Ensure radio init reuses existing audio service

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -150,15 +150,13 @@ class RadioController extends ChangeNotifier {
   /// initialized, enabling notification-based controls. When `false`, the
   /// controller will operate without posting notifications.
   Future<void> init({String? quality, bool startService = true}) async {
-    var serviceRunning = false;
-    if (!startService) {
-      serviceRunning = _isServiceHandler && _audioHandler != null;
-      if (!serviceRunning) {
-        try {
-          serviceRunning = await AudioService.running;
-        } catch (_) {
-          serviceRunning = false;
-        }
+    var serviceRunning = _isServiceHandler && _audioHandler != null;
+
+    if (!serviceRunning) {
+      try {
+        serviceRunning = await AudioService.running;
+      } catch (_) {
+        serviceRunning = false;
       }
     }
 


### PR DESCRIPTION
## Summary
- always check whether the background audio handler is already running before initializing the service
- keep notifications enabled and reuse the existing handler when the service is alive, avoiding the local handler fallback

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68c9b48bac2883269c7c4171d5c9a5d7