### PR TITLE
Avoid reinitializing radio audio service when handler already running

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -160,28 +160,23 @@ class RadioController extends ChangeNotifier {
       }
     }
 
-    if (serviceRunning) {
-      _notificationsEnabled = true;
-    } else {
-      _notificationsEnabled = startService;
-    }
-
+    _notificationsEnabled = serviceRunning || startService;
     debugPrint('RadioController.init: notificationsEnabled=$_notificationsEnabled');
 
     if (serviceRunning) {
       _resetAudioHandlerCompleter();
       _completeAudioHandlerCompleter();
-    } else if (_notificationsEnabled) {
+    } else if (!startService) {
+      _isServiceHandler = false;
+      _audioHandler = RadioAudioHandler(_player);
+      _resetAudioHandlerCompleter();
+      _completeAudioHandlerCompleter();
+    } else {
       await ensureAudioService();
       if (_hasError) {
         notifyListeners();
         return;
       }
-    } else {
-      _isServiceHandler = false;
-      _audioHandler = RadioAudioHandler(_player);
-      _resetAudioHandlerCompleter();
-      _completeAudioHandlerCompleter();
     }
 
     _streamsUnavailable = false;


### PR DESCRIPTION
## Summary
- detect whether the radio audio handler is already running before checking the startService guard
- keep notifications enabled when a handler exists, reuse the existing service connection, and only fall back to a local handler when both startService is false and no service is active

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b6a5b7c8832686175ed4677c0c39