### PR TITLE
Handle existing audio service when re-entering radio screen

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -151,14 +151,18 @@ class RadioController extends ChangeNotifier {
   /// controller will operate without posting notifications.
   Future<void> init({String? quality, bool startService = true}) async {
     final serviceRunning = await _isBackgroundServiceRunning();
+    final shouldUseService = serviceRunning || startService;
 
-    _notificationsEnabled = serviceRunning ? true : startService;
+    // Preserve notification controls whenever the background service is
+    // already active (or will be started) so we reuse the existing handler
+    // instead of downgrading to the local player-only implementation.
+    _notificationsEnabled = shouldUseService;
     debugPrint('RadioController.init: notificationsEnabled=$_notificationsEnabled');
 
     if (serviceRunning) {
       _audioHandlerCompleter ??= Completer<void>();
       _completeAudioHandlerCompleter();
-    } else if (!startService) {
+    } else if (!shouldUseService) {
       _isServiceHandler = false;
       _audioHandler = RadioAudioHandler(_player);
       _resetAudioHandlerCompleter();


### PR DESCRIPTION
## Summary
- compute whether the background audio service is already running before evaluating startService usage
- keep notification support enabled and reuse the existing handler when a background service is active, falling back to the local handler only when no service is needed

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c0ac622c8326abce9d0143dfcf7d