### PR TITLE
Reorder radio notification controls

### DIFF
--- a/lib/features/radio/radio_audio_handler.dart
+++ b/lib/features/radio/radio_audio_handler.dart
@@ -91,8 +91,8 @@ class RadioAudioHandler extends BaseAudioHandler with SeekHandler {
       'Playback event - playing: $playing, processingState: ${event.processingState}',
     );
     const controls = <MediaControl>[
-      MediaControl.play,
       MediaControl.pause,
+      MediaControl.play,
       MediaControl.stop,
     ];
 


### PR DESCRIPTION
## Summary
- reorder the radio playback controls so the pause action is shown first while keeping the compact indices the same

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c9175724832699a674a4e56186d4