### PR TITLE
Add secondary button for offer contact actions

### DIFF
--- a/lib/core/widgets/secondary_button.dart
+++ b/lib/core/widgets/secondary_button.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+class SecondaryButton extends StatelessWidget {
+  const SecondaryButton({
+    super.key,
+    required this.text,
+    this.icon,
+    this.onPressed,
+  });
+
+  final String text;
+  final IconData? icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final ButtonStyle style = FilledButton.styleFrom(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      minimumSize: const Size(48, 40),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+      textStyle: theme.textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w500),
+    ).copyWith(
+      backgroundColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.disabled)) {
+          return colorScheme.surfaceVariant;
+        }
+        return colorScheme.secondaryContainer;
+      }),
+      foregroundColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.disabled)) {
+          return colorScheme.onSurface.withOpacity(0.38);
+        }
+        return colorScheme.onSecondaryContainer;
+      }),
+      overlayColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.pressed)) {
+          return colorScheme.secondary.withOpacity(0.12);
+        }
+        if (states.contains(MaterialState.hovered) ||
+            states.contains(MaterialState.focused)) {
+          return colorScheme.secondary.withOpacity(0.08);
+        }
+        return null;
+      }),
+    );
+
+    if (icon != null) {
+      return FilledButton.tonalIcon(
+        onPressed: onPressed,
+        style: style,
+        icon: Icon(icon, size: 20),
+        label: Text(text),
+      );
+    }
+
+    return FilledButton.tonal(
+      onPressed: onPressed,
+      style: style,
+      child: Text(text),
+    );
+  }
+}

--- a/lib/features/mclub/offer_detail_screen.dart
+++ b/lib/features/mclub/offer_detail_screen.dart
@@ -10,6 +10,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:intl/intl.dart';
 import '../../core/services/api_service.dart';
 import '../../core/widgets/primary_button.dart';
+import '../../core/widgets/secondary_button.dart';
 import 'offer_model.dart';
 import '../auth/club_card_screen.dart';
 import 'widgets/rating_widget.dart';
@@ -539,24 +540,43 @@ class _OfferDetailScreenState extends State<OfferDetailScreen> {
                       ),
 
                     const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: PrimaryButton(
-                            text: 'Отказали в скидке?',
-                            onPressed: () {},
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: PrimaryButton(
-                            text: 'Контакт менеджера',
-                            onPressed: (sponsorEmail == null || sponsorEmail.trim().isEmpty)
-                                ? null
-                                : () => _mailto(sponsorEmail!),
-                          ),
-                        ),
-                      ],
+                    LayoutBuilder(
+                      builder: (context, constraints) {
+                        const spacing = 12.0;
+                        final maxWidth = constraints.maxWidth.isFinite
+                            ? constraints.maxWidth
+                            : MediaQuery.of(context).size.width;
+                        final useFullWidth = maxWidth <= 400;
+                        final buttonWidth = useFullWidth
+                            ? maxWidth
+                            : (maxWidth - spacing) / 2;
+
+                        return Wrap(
+                          spacing: spacing,
+                          runSpacing: 8,
+                          children: [
+                            SizedBox(
+                              width: buttonWidth,
+                              child: SecondaryButton(
+                                text: 'Отказали в скидке?',
+                                icon: Icons.support_agent,
+                                onPressed: () {},
+                              ),
+                            ),
+                            SizedBox(
+                              width: buttonWidth,
+                              child: SecondaryButton(
+                                text: 'Контакт менеджера',
+                                icon: Icons.mail,
+                                onPressed:
+                                    (sponsorEmail == null || sponsorEmail.trim().isEmpty)
+                                        ? null
+                                        : () => _mailto(sponsorEmail!),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
                     ),
 
                     // Подзаголовок "Адреса"


### PR DESCRIPTION
## Summary
- add a reusable SecondaryButton widget that provides a compact tonal button with icon support and improved disabled styling
- replace the offer detail action row with a responsive layout that uses the new SecondaryButton and appropriate icons

## Testing
- flutter analyze *(fails: `flutter` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d2464c448326aaf1567c63f79657