### PR TITLE
Enable Flutter localization code generation in pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  generate: true
 
   assets:
     - assets/images/


### PR DESCRIPTION
## Summary
- enable Flutter to emit the flutter_gen synthetic package consumed by AppLocalizations by turning on code generation

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9dda157cc83268f2db51cf722741e