### PR TITLE
Bump app version to 4.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_club
 description: M-Club mobile app
 publish_to: "none"
-version: 0.1.0+1
+version: 4.0.1+1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- bump the app's declared version to 4.0.1+1 in `pubspec.yaml`

## Testing
- Flutter SDK unavailable in the execution environment (unable to run `flutter pub get` or build commands)


------
https://chatgpt.com/codex/tasks/task_e_68c9e54c7214832680bd1089a4dd75aa