### PR TITLE
Add keep resources for notification icon

### DIFF
--- a/android/app/src/main/res/values/keep.xml
+++ b/android/app/src/main/res/values/keep.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/radio_notification_icon">
+</resources>


### PR DESCRIPTION
## Summary
- add a keep resources file so the radio notification icon survives resource shrinking

## Testing
- `./gradlew assembleRelease` *(fails: Gradle wrapper script is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0cba74988326b34a734db09da2d0