### PR TITLE
Enable release minification and resource shrinking

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -63,6 +63,12 @@ android {
     buildTypes {
         release {
             signingConfig = signingConfigs.findByName("release") ?: signingConfigs.getByName("debug")
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- enable code shrinking, resource shrinking, and default + custom ProGuard rules for the Android release build

## Testing
- `./gradlew app:assembleRelease` *(fails: gradle wrapper script is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0e30ace48326ab1d9e589a4f7c5b