### PR TITLE
Add ProGuard rules for radio background audio

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,16 @@
+# Keep the audio service implementation so background playback remains functional
+-keep class com.ryanheise.audioservice.** { *; }
+-dontwarn com.ryanheise.audioservice.**
+
+# Retain AndroidX media classes that the audio service depends on
+-keep class androidx.media.** { *; }
+-dontwarn androidx.media.**
+
+# ExoPlayer powers streaming playback for the radio feature
+-keep class com.google.android.exoplayer2.** { *; }
+-dontwarn com.google.android.exoplayer2.**
+
+# Retain generated Flutter plugin services referenced by the radio module
+-keep class io.flutter.plugins.GeneratedPluginRegistrant { *; }
+-keep class com.ryanheise.audioservice.AudioService { *; }
+-keep class com.ryanheise.audioservice.MediaButtonReceiver { *; }


### PR DESCRIPTION
## Summary
- add a dedicated ProGuard configuration file for the Android app
- keep and silence warnings for AudioService, AndroidX media, and ExoPlayer classes used by the radio feature
- retain generated plugin registrant and audio service components so background playback survives minification

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca0e90e0d8832690b0ae89d8c8e102