### PR TITLE
Update radio notification icon reference

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -366,7 +366,7 @@ class RadioController extends ChangeNotifier {
         config: const AudioServiceConfig(
           androidNotificationChannelId: 'm_club_radio_channel',
           androidNotificationChannelName: 'M-Club Radio',
-          androidNotificationIcon: 'drawable/radio_notification_icon',
+          androidNotificationIcon: 'mipmap/ic_launcher',
           androidNotificationOngoing: true,
         ),
       );


### PR DESCRIPTION
## Summary
- point the audio service notification icon to the default launcher resource

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca152385e48326a88d33d1360e6817