### PR TITLE
Handle null audio handler in radio processing state

### DIFF
--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -24,8 +24,9 @@ class RadioController extends ChangeNotifier {
     _player.processingStateStream.listen((state) async {
       if (state == ProcessingState.idle && _player.audioSource != null) {
         _hasError = true;
-        await _audioHandlerReady;
-        await _audioHandler!.stop();
+        if (_audioHandler != null) {
+          await _audioHandler!.stop();
+        }
       }
       notifyListeners();
     });


### PR DESCRIPTION
## Summary
- adjust the processing state listener to avoid awaiting the audio handler readiness
- guard the stop call behind a null-check before stopping the audio handler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca16ef7cd08326bf5b20a4422278a7